### PR TITLE
Pod swagger examples

### DIFF
--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -15,6 +15,10 @@ info:
     system even if ome subset of the request would have succeeded.
     - If this contract cannot be met for any reason then this is an error
     and the response code will be 50X.
+servers:
+  - url: /
+host: 'yourpodURL.symphony.com'
+basePath: '/pod'
 paths:
   '/v1/companycert/list':
     get:
@@ -46,22 +50,53 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/CompanyCertInfoList'
+          examples:
+            application/json:
+              - companyCertAttributes:
+                  name: agentservice
+                  type:
+                    type: USER
+                  status:
+                    type: TRUSTED
+                companyCertInfo:
+                  fingerPrint: "300a..."
+                  lastSeen: 0
+                  updatedAt: 0
+                  updatedBy: 0
+                  commonName: agentservice
+                  expiryDate: 1781886755000
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/companycert/create':
     post:
       summary: Create a company trusted or untrusted certificate.
@@ -88,22 +123,75 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/CompanyCertDetail'
+          examples:
+            application/json:
+              - companyCertAttributes:
+                  name: jira
+                  type:
+                    type: USER
+                  status:
+                    type: KNOWN
+                companyCertInfo:
+                  fingerPrint: "450369..."
+                  issuerFingerPrint: "c35680..."
+                  lastSeen: 1529994790226
+                  updatedAt: 1529598066602
+                  updatedBy: 9208409884327
+                  commonName: jiraWebHookIntegration
+                  expiryDate: 1768510565000
+                certInfo:
+                  - name: General
+                    attributes:
+                      - name: Issuer
+                        value: C=US O=Symphony Communications LLC CN=bot_user_provisioning
+                      - name: Subject
+                        value: C=US OU=NOT FOR PRODUCTION USE O=Symphony Communications LLC CN=jiraWebHookIntegration
+                      - name: Signature Algorithm
+                        value: SHA256withRSA
+                  - name: Validity
+                    attributes:
+                      - name: Not Before
+                        value: Mon Jan 15 20:56:05 UTC 2018
+                      - name: Not After
+                        value: Thu Jan 15 20:56:05 UTC 2026
+                  - name: Public Key
+                    attributes:
+                      - name: Algorithm
+                        value: RSA
+                      - name: Format
+                        value: X.509
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/companycert/delete':
     post:
       summary: Delete a company certificate
@@ -129,22 +217,42 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: OK
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/companycert/{fingerPrint}/get':
     get:
       summary: Get the details of a company certificate
@@ -170,22 +278,75 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/CompanyCertDetail'
+          examples:
+            application/json:
+              - companyCertAttributes:
+                  name: jira
+                  type:
+                    type: USER
+                  status:
+                    type: KNOWN
+                companyCertInfo:
+                  fingerPrint: "450369..."
+                  issuerFingerPrint: "c35680..."
+                  lastSeen: 1529994790226
+                  updatedAt: 1529598066602
+                  updatedBy: 9208409884327
+                  commonName: jiraWebHookIntegration
+                  expiryDate: 1768510565000
+                certInfo:
+                  - name: General
+                    attributes:
+                      - name: Issuer
+                        value: C=US O=Symphony Communications LLC CN=bot_user_provisioning
+                      - name: Subject
+                        value: C=US OU=NOT FOR PRODUCTION USE O=Symphony Communications LLC CN=jiraWebHookIntegration
+                      - name: Signature Algorithm
+                        value: SHA256withRSA
+                  - name: Validity
+                    attributes:
+                      - name: Not Before
+                        value: Mon Jan 15 20:56:05 UTC 2018
+                      - name: Not After
+                        value: Thu Jan 15 20:56:05 UTC 2026
+                  - name: Public Key
+                    attributes:
+                      - name: Algorithm
+                        value: RSA
+                      - name: Format
+                        value: X.509
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/companycert/{fingerPrint}/update':
     post:
       summary: Update a company certificate
@@ -216,22 +377,42 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: OK
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/companycert/{fingerPrint}/issuedBy':
     get:
       summary: |
@@ -259,22 +440,53 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/CompanyCertInfoList'
+          examples:
+            application/json:
+              - companyCertAttributes:
+                  name: agentservice
+                  type:
+                    type: USER
+                  status:
+                    type: TRUSTED
+                companyCertInfo:
+                  fingerPrint: 300a...
+                  lastSeen: 0
+                  updatedAt: 0
+                  updatedBy: 0
+                  commonName: agentservice
+                  expiryDate: 1781886755000
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/companycert/podmanaged/list':
     get:
       summary: List all trusted certs
@@ -305,22 +517,53 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/CompanyCertInfoList'
+          examples:
+            application/json:
+              - companyCertAttributes:
+                  name: agentservice
+                  type:
+                    type: USER
+                  status:
+                    type: TRUSTED
+                companyCertInfo:
+                  fingerPrint: 300a...
+                  lastSeen: 0
+                  updatedAt: 0
+                  updatedBy: 0
+                  commonName: agentservice
+                  expiryDate: 1781886755000
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/companycert/type/list':
     post:
       summary: List all certs of the given types
@@ -357,22 +600,53 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/CompanyCertInfoList'
+          examples:
+            application/json:
+              - companyCertAttributes:
+                  name: agentservice
+                  type:
+                    type: USER
+                  status:
+                    type: TRUSTED
+                companyCertInfo:
+                  fingerPrint: 300a...
+                  lastSeen: 0
+                  updatedAt: 0
+                  updatedBy: 0
+                  commonName: agentservice
+                  expiryDate: 1781886755000
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/podcert':
     get:
       summary: |
@@ -386,10 +660,17 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/PodCertificate'
+          examples:
+            application/json:
+              certificate: PEM_CERTIFICATE
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/connection/list':
     get:
       summary: List of requesting user's connection
@@ -434,26 +715,54 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/UserConnectionList'
+          examples:
+            application/json:
+              - userId: 769658112378
+                status: ACCEPTED
+                updatedAt: 1471018076255
+              - userId: 7078106103809
+                status: PENDING_INCOMING
+                updatedAt: 1467562406219
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
           description: 'Not Found: Connection cannot be found.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. Connection cannot be found. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/connection/create':
     post:
       summary: Sends an invitation to connect with another user
@@ -479,26 +788,53 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/UserConnection'
+          examples:
+            application/json:
+              userId: 7078106126503
+              status: PENDING_OUTGOING
+              firstRequestedAt: 1470018076306
+              updatedAt: 1471018076255
+              requestCounter: 1
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
-          description: 'Not Found: User cannot be found.'
+          description: 'Not Found: Connection cannot be found.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. User cannot be found. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/connection/accept':
     post:
       summary: Accept the connection request for the requesting user
@@ -524,26 +860,53 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/UserConnection'
+          examples:
+            application/json:
+              userId: 7078106126503
+              status: ACCEPTED
+              firstRequestedAt: 1470018076306
+              updatedAt: 1471018076255
+              requestCounter: 1
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
           description: 'Not Found: Connection cannot be found.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. Connection cannot be found. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/connection/reject':
     post:
       summary: Reject the connection request for the requesting user.
@@ -572,26 +935,53 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/UserConnection'
+          examples:
+            application/json:
+              userId: 7078106126503
+              status: REJECTED
+              firstRequestedAt: 1470018076306
+              updatedAt: 1471018076255
+              requestCounter: 1
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
           description: 'Not Found: Connection cannot be found.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. Connection cannot be found. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/connection/user/{userId}/info':
     get:
       summary: The status of the connection invitation to another user.
@@ -615,26 +1005,50 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/UserConnection'
+          examples:
+            application/json:
+              userId: 769658112378
+              status: ACCEPTED
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
           description: 'Not Found: Connection cannot be found.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. Connection cannot be found. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/connection/user/{uid}/remove':
     post:
       summary: Removes a connection with a user.
@@ -662,26 +1076,50 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: Connection Removed.
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
           description: 'Not Found: Connection cannot be found.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. Connection cannot be found. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/im/create':
     post:
       summary: Create a new single or multi party instant message conversation between the caller and specified users.
@@ -724,22 +1162,41 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/Stream'
+          examples:
+            application/json:
+              id: xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/im/{id}/update':
     post:
       summary: Update the attributes of an existing IM.
@@ -770,26 +1227,54 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V1IMDetail'
+          examples:
+            application/json:
+              V1IMAttributes:
+                pinnedMessageId: vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ
+              IMSystemInfo:
+                id: usnBKBkH_BVrGOiVpaupEH___okFfE7QdA
+                creationDate: 1610520703317
+                active: true
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '451':
           description: 'Unavailable for Legal Reasons: Compliance Issues found in IM update request.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 451
+              message: Compliance issues found in room update
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/im/{id}/info':
     get:
       summary: Get information about a partcular IM.
@@ -813,22 +1298,46 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V1IMDetail'
+          examples:
+            application/json:
+              V1IMAttributes:
+                pinnedMessageId: vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ
+              IMSystemInfo:
+                id: usnBKBkH_BVrGOiVpaupEH___okFfE7QdA
+                creationDate: 1610520703317
+                active: true
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/presence/feed/create':
     post:
       summary: Create Presence status feed.
@@ -855,22 +1364,41 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/StringId'
+          examples:
+            application/json:
+              id: c4dca251-8639-48db-a9d4-f387089e17cf
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/presence/feed/{feedId}/read':
     get:
       summary: Read a presence status feed.
@@ -897,22 +1425,46 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V2PresenceList'
+          examples:
+            application/json:
+              - category: AVAILABLE
+                userId: 14568529068038
+                timestamp: 1533928483800
+              - category: ON_THE_PHONE
+                userId: 974217539631
+                timestamp: 1503286226030
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/presence/feed/{feedId}/delete':
     post:
       summary: Delete a presence status feed.
@@ -940,22 +1492,41 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/StringId'
+          examples:
+            application/json:
+              id: c4dca251-8639-48db-a9d4-f387089e17cf
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v3/room/create':
     post:
       summary: Create a new chatroom.
@@ -985,26 +1556,70 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V3RoomDetail'
+          examples:
+            application/json:
+              roomAttributes:
+                name: API room
+                keywords:
+                  - key: region
+                    value: EMEA
+                  - key: lead
+                    value: Bugs Bunny
+                description: Created via the API
+                membersCanInvite: true
+                discoverable: false
+                readOnly: false
+                copyProtected: false
+                crossPod: false
+                viewHistory: false
+                multiLateralRoom: false
+                public: false
+                groupChat: false
+              roomSystemInfo:
+                id: bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA
+                creationDate: 1547661232368
+                createdByUserId: 14362370637825
+                active: true
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '451':
           description: 'Unavailable for Legal Reasons: Compliance Issues found in room creation request.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 451
+              message: Compliance issues found in room creation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v3/room/search':
     post:
       summary: Search rooms according to the specified criteria.
@@ -1043,22 +1658,87 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V3RoomSearchResults'
+          examples:
+            application/json:
+              count: 2
+              skip: 0
+              limit: 10
+              query:
+                query: automobile
+                labels:
+                  - industry
+                active: true
+                creator:
+                  id: 7696581411197
+              rooms:
+                - roomAttributes:
+                    name: Automobile Industry Room
+                    description: Room to discuss car companies
+                    membersCanInvite: true
+                    readOnly: false
+                    copyProtected: false
+                    crossPod: false
+                    viewHistory: false
+                    public: false
+                    multiLateralRoom: false
+                  roomSystemInfo:
+                    id: tzwvAZIdDMG3ZPRxv+xsgH///qr+JJkWdA==
+                    creationDate: 1464615003895
+                    createdByUserId: 7696581411197
+                    active: true
+                - roomAttributes:
+                    name: Tesla Room
+                    keywords:
+                      - key: industry
+                        value: automobile
+                    description: Discussions on TSLA
+                    membersCanInvite: true
+                    readOnly: false
+                    copyProtected: false
+                    crossPod: false
+                    viewHistory: false
+                    public: false
+                    multiLateralRoom: false
+                  roomSystemInfo:
+                    id: o6UkQ1TEmU0Tf/DHUlZrCH///qr+JQowdA==
+                    creationDate: 1464614974947
+                    createdByUserId: 7696581411197
+                    active: true
+              facetedMatchCount:
+                - facet: industry
+                  count: 1
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v3/room/{id}/info':
     get:
       summary: Get information about a partcular chatroom.
@@ -1082,22 +1762,62 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V3RoomDetail'
+          examples:
+            application/json:
+              roomAttributes:
+                name: API room
+                keywords:
+                  - key: region
+                    value: EMEA
+                  - key: lead
+                    value: Bugs Bunny
+                description: Created via the API
+                membersCanInvite: true
+                discoverable: false
+                readOnly: false
+                copyProtected: false
+                crossPod: false
+                viewHistory: false
+                multiLateralRoom: false
+                public: false
+                groupChat: false
+              roomSystemInfo:
+                id: bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA
+                creationDate: 1547661232368
+                createdByUserId: 14362370637825
+                active: true
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/room/{id}/setActive':
     post:
       summary: Deactivate or reactivate a chatroom. At creation, a new chatroom is active.
@@ -1127,22 +1847,54 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/RoomDetail'
+          examples:
+            application/json:
+              roomAttributes:
+                name: API room
+                description: Updated via the API
+                membersCanInvite: true
+                discoverable: true
+              roomSystemInfo:
+                id: HNmksPVAR6-f14WqKXmqHX___qu8LMLgdA
+                creationDate: 1461426797875
+                createdByUserId: 7078106103809
+                active: false
+              immutableRoomAttributes:
+                readOnly: false
+                copyProtected: false
+                public: false
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v3/room/{id}/update':
     post:
       summary: Update the attributes of an existing chatroom.
@@ -1173,26 +1925,71 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V3RoomDetail'
+          examples:
+            application/json:
+              roomAttributes:
+                name: API room updated
+                keywords:
+                  - key: region
+                    value: EMEA
+                  - key: lead
+                    value: Bugs Bunny
+                description: Updated via the API
+                membersCanInvite: true
+                discoverable: false
+                readOnly: false
+                copyProtected: false
+                crossPod: false
+                viewHistory: true
+                multiLateralRoom: false
+                pinnedMessageId: vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ
+                public: true
+                groupChat: false
+              roomSystemInfo:
+                id: bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA
+                creationDate: 1547661232368
+                createdByUserId: 14362370637825
+                active: true
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '451':
           description: 'Unavailable for Legal Reasons: Compliance Issues found in room update request.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 451
+              message: Compliance issues found in room update
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/room/{id}/membership/add':
     post:
       summary: Adds new member to an existing room.
@@ -1223,22 +2020,42 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: Member added
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/room/{id}/membership/remove':
     post:
       summary: Removes member from an existing room.
@@ -1269,22 +2086,42 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: Member removed
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/room/{id}/membership/promoteOwner':
     post:
       summary: Promotes user to owner.
@@ -1315,22 +2152,42 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: Member promoted to owner
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/room/{id}/membership/demoteOwner':
     post:
       summary: Demotes room owner.
@@ -1361,22 +2218,42 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: Owner demoted
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/room/{id}/membership/list':
     get:
       summary: Lists current members of an existing room.
@@ -1400,22 +2277,51 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/MembershipList'
+          examples:
+            application/json:
+              - id: 7078106103900
+                owner: false
+                joinDate: 1461430710531
+              - id: 7078106103809
+                owner: true
+                joinDate: 1461426797875
+              - id: 7078106103810
+                owner: true
+                joinDate: 1461426797833
+                addedThroughGroups:
+                  - 68719476744
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/sessioninfo':
     get:
       summary: Get information about the current user's session.
@@ -1438,18 +2344,34 @@ paths:
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/user':
     get:
       summary: Get user information
@@ -1497,21 +2419,37 @@ paths:
         '204':
           description: 'No user found.'
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v3/users':
     get:
       summary: |
@@ -1564,24 +2502,84 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V2UserList'
+          examples:
+            application/json:
+              users:
+                - id: 15942919536460
+                  emailAddress: technicalwriter@symphony.com
+                  firstName: Technical
+                  lastName: Writer
+                  displayName: Technical Writer
+                  title: Technical Writer
+                  company: Symphony
+                  department: Marketing // if internal user
+                  username: tw
+                  accountType: NORMAL 
+                  location: France // if internal user
+                  avatars:
+                    - size: original
+                      url: ../avatars/static/150/default.png
+                    - size: small
+                      url: ../avatars/static/50/default.png
+                - id: 15942919536461
+                  emailAddress: serviceaccount@symphony.com
+                  firstName: null
+                  lastName: null
+                  displayName: Service Account
+                  title: null
+                  company: pod232
+                  department: Marketing // if internal user
+                  username: SA
+                  location: France // if internal user
+                  accountType: SYSTEM
+                  avatars:
+                    - size: original
+                      url: ../avatars/static/150/default.png
+                    - size: small
+                      url: ../avatars/static/50/default.png
+              errors:
+                - error: invalid.format
+                  email: notavalidemail
+                - error: invalid.format
+                  id: 654321
         '204':
           description: 'No user found.'
+          examples:
+            application/json:
+              code: 204
+              message: // No user found. See response body for further details.
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/user/presence/register':
     post:
       summary: Register interest in a user's presence status
@@ -1608,26 +2606,50 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: OK
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
           description: 'Not Found: user id cannot be located.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. User id cannot be located. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/user/presence':
     get:
       summary: Get presence information about the requesting user.
@@ -1646,18 +2668,35 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V2Presence'
+          examples:
+            application/json:
+              category: AVAILABLE
+              userId: 14568529068038
+              timestamp: 1533928483800
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Invalid session token'
+          description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
     post:
       summary: Set the presence of the requesting user.
       consumes:
@@ -1692,18 +2731,35 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V2Presence'
+          examples:
+            application/json:
+              category: AWAY
+              userId: 14568529068038
+              timestamp: 1533928483800
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Invalid session token.'
+          description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v3/user/{uid}/presence':
     get:
       summary: Get presence information about a particular user.
@@ -1743,26 +2799,51 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V2Presence'
+          examples:
+            application/json:
+              category: AVAILABLE
+              userId: 14568529068038
+              timestamp: 1533928483800
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
           description: 'Not Found: user id cannot be located.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. User id cannot be located. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/users/presence':
     get:
       summary: Get presence information about all company (pod) users.
@@ -1809,22 +2890,46 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V2PresenceList'
+          examples:
+            application/json:
+              - category: AVAILABLE
+                userId: 14568529068038
+                timestamp: 1533928483800
+              - category: OFFLINE
+                userId: 974217539631
+                timestamp: 1503286226030
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v3/user/presence':
     post:
       summary: Set presence information for a particular user.
@@ -1858,26 +2963,51 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V2Presence'
+          examples:
+            application/json:
+              category: AVAILABLE
+              userId: 14568529068038
+              timestamp: 1533928483800
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized.'
+          description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
-          description: 'Forbidden.'
+          description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
           description: 'Not Found: user id cannot be located.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. User id cannot be located. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/user/search':
     post:
       summary: Search for users by name or email address
@@ -1920,24 +3050,76 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/UserSearchResults'
+          examples:
+            application/json:
+              count: 1
+              skip: 0
+              limit: 1
+              searchQuery:
+                query: jane
+                filters:
+                  title: Sales Manager
+                  company: Symphony
+                  location: San Francisco
+                  marketCoverage: EMEA
+                  responsibility: BAU
+                  function: Trade Management
+                  instrument: Securities
+                  accountTypes:
+                    - NORMAL
+              users:
+                - id: 13056700581099
+                  emailAddress: janedoe@symphony.com
+                  firstName: Jane
+                  lastName: Doe
+                  displayName: Jane Doe
+                  title: Sales Manager
+                  company: Symphony
+                  location: San Francisco
+                  accountType: NORMAL
+                  avatars:
+                    - size: original
+                      url: ../avatars/static/150/default.png
+                    - size: small
+                      url: ../avatars/static/50/default.png
         '204':
           description: 'No user found.'
+          examples:
+            application/json:
+              code: 204
+              message: // No user found. See response body for further details.
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/streams/list':
     post:
       summary: |
@@ -1975,24 +3157,50 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/StreamList'
+          examples:
+            application/json:
+              - id: iWyZBIOdQQzQj0tKOLRivX___qu6YeyZdA
+                crossPod: false
+                active: true
+                streamType:
+                  type: POST
+                streamAttributes:
+                  members:
+                    - 7215545078229
         '204':
             description: 'Stream not found.'
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/streams/list':
     post:
       summary: |
@@ -2037,24 +3245,59 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/StreamList'
+          examples:
+            application/json:
+              - id: Jq6uPN4-uIop7lvjOkYdXX___nn9I0PHdA
+                crossPod: false
+                active: true
+                streamType:
+                  type: IM
+                streamAttributes:
+                  members:
+                    - 9139690966401
+                    - 9139691042211
+              - id: iWyZBIOdQQzQj0tKOLRivX___qu6YeyZdA
+                crossPod: false
+                active: true
+                streamType:
+                  type: POST
+                streamAttributes:
+                  members:
+                    - 7215545078229
         '204':
           description: 'Stream not found.'
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/streams/{sid}/info':
     get:
       summary: Get information about a partcular stream.
@@ -2078,22 +3321,52 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V2StreamAttributes'
+          examples:
+            application/json:
+              id: BZQYepoT0Zf4vL_jpeMPqn___oEWvVy3dA
+              crossPod: false
+              origin: INTERNAL
+              active: true
+              lastMessageDate: 1644590972696
+              streamType:
+                type: ROOM
+              roomAttributes:
+                name: API room
+                groups:
+                  - id: 68719476744
+                    addedBy: 68719476743
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/streams/{sid}/attachments':
     get:
       summary: Get attachments in a particular stream.
@@ -2145,22 +3418,60 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/StreamAttachmentResponse'
+          examples:
+            application/json:
+              - messageId: PYLHNm/1K6p...peOpj+FbQ
+                userId: USER_ID
+                ingestionDate: 1548089933946
+                fileId: internal_143623
+                name: butterfly.jpg
+                size: 70186
+                contentType: image/jpeg
+                previews:
+                  - fileId: internal_143623
+                    width: 600
+              - messageId: KpjYuzMLR+JK1co7QBfukX///peOpZmdbQ==
+                userId: USER_ID
+                ingestionDate: 1548089976418
+                fileId: internal_1436237
+                name: car.png
+                size: 15754
+                contentType: image/png
+                previews:
+                  - fileId: internal_14362370637
+                    width: 600
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/app/entitlement/list':
     get:
       summary: Get the list of application entitlements for the company
@@ -2181,22 +3492,45 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/PodAppEntitlementList'
+          examples:
+            application/json:
+              - appId: djApp
+                appName: Dow Jones
+                enable: true
+                listed: true
+                install: true
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
     post:
       summary: Update the application entitlements for the company
       consumes:
@@ -2221,22 +3555,55 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/PodAppEntitlementList'
+          examples:
+            application/json:
+              - appId: djApp
+                appName: Dow Jones
+                enable: true
+                listed: true
+                install: false
+              - appId: spcapiq
+                appName: S&P Capital IQ Data
+                enable: true
+                listed: true
+                install: false
+              - appId: selerity
+                appName: Selerity Context
+                enable: false
+                listed: true
+                install: true
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/disclaimer/{did}':
     get:
       summary: Get a disclaimer by disclaimer id
@@ -2262,22 +3629,48 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/Disclaimer'
+          examples:
+            application/json:
+              id: 571d20dae4b042aaf06d2e7c
+              name: New Enterprise Disclaimer
+              content: This is a second enterprise disclaimer.
+              frequencyInHours: 168
+              isDefault: false
+              isActive: true
+              createdDate: 1461526746875
+              modifiedDate: 1461526746875
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/disclaimer/list':
     get:
       summary: List all disclaimers for the company (pod)
@@ -2298,22 +3691,56 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/DisclaimerList'
+          examples:
+            application/json:
+              - id: 571d2052e4b042aaf06d2e7a
+                name: Enterprise Disclaimer
+                content: This is a disclaimer for the enterprise.
+                frequencyInHours: 24
+                isDefault: false
+                isActive: true
+                createdDate: 1461526610846
+                modifiedDate: 1461526610846
+              - id: 571d20dae4b042aaf06d2e7c
+                name: New Enterprise Disclaimer
+                content: This is a second enterprise disclaimer.
+                frequencyInHours: 168
+                isDefault: false
+                isActive: true
+                createdDate: 1461526746875
+                modifiedDate: 1461526746875
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/disclaimer/{did}/users':
     get:
       summary: List all users assigned to this disclaimer
@@ -2339,22 +3766,41 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/UserIdList'
+          examples:
+            application/json:
+              - 7215545078541
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/group/list':
     get:
       summary: Get a list of all Information Barrier Groups
@@ -2375,22 +3821,56 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/GroupList'
+          examples:
+            application/json:
+              - id: 571db1f2e4b027c4f055a594
+                name: Group 1
+                active: true
+                memberCount: 1
+                policies:
+                  - 571db2e4e4b012df6341f393
+                createdDate: 1461563890135
+                modifiedDate: 1461563926812
+              - id: 571db20ae4b012df6341f391
+                name: Group 2
+                active: true
+                memberCount: 1
+                policies:
+                  - 571db2e4e4b012df6341f393
+                createdDate: 1461563914581
+                modifiedDate: 1461564112286
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/group/{gid}/membership/list':
     get:
       summary: Get the list of userids in this Information Barrier Group
@@ -2429,26 +3909,49 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/IntegerList'
+          examples:
+            application/json:
+              - 7215545078541
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
           description: 'Not Found: Group cannot be found.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. Group cannot be found. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/group/{gid}/membership/add':
     post:
       summary: Add members to an Information Barrier group.
@@ -2479,22 +3982,43 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/BulkActionResult'
+          examples:
+            application/json:
+              overallResult: SUCCESS
+              results:
+                - ""
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/group/{gid}/membership/remove':
     post:
       summary: Remove members from an Information Barrier group
@@ -2525,22 +4049,43 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/BulkActionResult'
+          examples:
+            application/json:
+              overallResult: SUCCESS
+              results:
+                - ""
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/im/create':
     post:
       summary: Create a new single or multi party instant message conversation
@@ -2579,22 +4124,41 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/Stream'
+          examples:
+            application/json:
+              id: xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/messagesuppression/{id}/suppress':
     post:
       summary: Suppress a message
@@ -2624,18 +4188,34 @@ paths:
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/policy/list':
     get:
       summary: Get all Information Policies
@@ -2656,22 +4236,56 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/PolicyList'
+          examples:
+            application/json:
+              - id: 56e9df05e4b00737e3d3b82d
+                policyType: BLOCK
+                active: true
+                groups:
+                  - 56e9def8e4b0b406041812e6
+                  - 56e9deffe4b0b406041812e7
+                createdDate: 1458167557358
+                modifiedDate: 1458330606752
+              - id: 571cd64de4b042aaf06d2d8b
+                policyType: BLOCK
+                active: true
+                groups:
+                  - 571cd646e4b042aaf06d2d84
+                  - 571cd64ce4b042aaf06d2d8a
+                createdDate: 1461507661146
+                modifiedDate: 1461507661146
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/room/{id}/setActive':
       post:
         summary: Deactivate or reactivate a chatroom via AC Portal.
@@ -2702,21 +4316,37 @@ paths:
             schema:
               $ref: '#/definitions/RoomDetail'
           '400':
-            description: 'Client error.'
+            description: 'Client error, see response body for further details.'
             schema:
               $ref: '#/definitions/Error'
+            examples:
+              application/json:
+                code: 400
+                message: // Client error, see response body for further details.
           '401':
             description: 'Unauthorized: Session tokens invalid.'
             schema:
               $ref: '#/definitions/Error'
+            examples:
+              application/json:
+                code: 401
+                message: Invalid session
           '403':
             description: 'Forbidden: Caller lacks necessary entitlement.'
             schema:
               $ref: '#/definitions/Error'
+            examples:
+              application/json:
+                code: 403
+                message: The user lacks the required entitlement to perform this operation
           '500':
             description: 'Server error, see response body for further details.'
             schema:
               $ref: '#/definitions/Error'
+            examples:
+              application/json:
+                code: 500
+                message: // Server error, see response body for further details.
   '/v1/admin/room/{id}/membership/list':
     get:
       summary: Lists current and previous members of an existing room.
@@ -2745,22 +4375,51 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/MembershipList'
+          examples:
+            application/json:
+              - id: 7078106103900
+                owner: false
+                joinDate: 1461430710531
+              - id: 7078106103809
+                owner: true
+                joinDate: 1461426797875
+              - id: 7078106103810
+                owner: true
+                joinDate: 1461426797833
+                addedThroughGroups:
+                  - 68719476744
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/room/{id}/membership/add':
     post:
       summary: Add a member to an existing room.
@@ -2792,21 +4451,37 @@ paths:
           schema:
             $ref: '#/definitions/SuccessResponse'
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/room/{id}/membership/remove':
     post:
       summary: Remove a member from a room.
@@ -2838,21 +4513,37 @@ paths:
           schema:
             $ref: '#/definitions/SuccessResponse'
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/admin/user/list':
     get:
       summary: Retrieve a list of all users in the company (pod)
@@ -2884,22 +4575,86 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/V2UserDetailList'
+          examples:
+            application/json:
+              - userAttributes:
+                  emailAddress: nexus.user@email.com
+                  userName: nexus.user
+                  displayName: nexus.user
+                  accountType: SYSTEM
+                userSystemInfo:
+                  id: 9826885173290
+                  status: ENABLED
+                  suspended: false
+                  createdDate: 1499375475000
+                  createdBy: "9826885173255"
+                  lastUpdatedDate: 1499375475852
+                  lastLoginDate: 1504899124191
+                roles:
+                  - USER_PROVISIONING
+                  - CONTENT_MANAGEMENT
+                  - INDIVIDUAL
+              - userAttributes:
+                  emailAddress: admin@mail.com
+                  firstName: admin
+                  lastName: admin
+                  userName: admin@mail.com
+                  displayName: Admin Admin
+                  companyName: Company Name
+                  department: Departament
+                  division: Division
+                  title: Administrator
+                  twoFactorAuthPhone: "+15419999999"
+                  workPhoneNumber: "+15419999999"
+                  mobilePhoneNumber: "+15419999999"
+                  accountType: NORMAL
+                  assetClasses:
+                    - Currencies
+                  industries:
+                    - Technology
+                userSystemInfo:
+                  id: 7696581394433
+                  status: ENABLED
+                  suspended: false
+                  createdDate: 1438054194000
+                  lastUpdatedDate: 1527532171729
+                  lastLoginDate: 1523912043015
+                roles:
+                  - SUPER_COMPLIANCE_OFFICER
+                  - INDIVIDUAL
+                  - SUPER_ADMINISTRATOR
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/find':
     post:
       summary: Find a user based on attributes
@@ -2936,22 +4691,81 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/UserDetailList'
+          examples:
+            application/json:
+              - userAttributes:
+                  emailAddress: janedoe@symphony.com
+                  firstName: Jane
+                  lastName: Doe
+                  userName: jane.doe
+                  displayName: Jane Doe
+                  accountType: NORMAL
+                  assetClasses:
+                    - Commodities
+                  industries:
+                    - Financials
+                    - Healthcare
+                userSystemInfo:
+                  id: 9826885173258
+                  status: ENABLED
+                  suspended: true
+                  suspensionReason: The user will be OOO due to a mandatory leave
+                  suspendedUntil: 1601546400
+                  createdDate: 1499347606000
+                  createdBy: "9826885173252"
+                  lastUpdatedDate: 1499348554853
+                  lastLoginDate: 1504839044527
+                roles:
+                  - INDIVIDUAL
+              - userAttributes:
+                  emailAddress: nexus.user@email.com
+                  userName: nexus.user
+                  displayName: nexus.user
+                  accountType: SYSTEM
+                userSystemInfo:
+                  id: 9826885173290
+                  status: ENABLED
+                  suspended: false
+                  createdDate: 1499375475000
+                  createdBy: "9826885173255"
+                  lastUpdatedDate: 1499375475852
+                  lastLoginDate: 1504899124191
+                roles:
+                  - USER_PROVISIONING
+                  - CONTENT_MANAGEMENT
+                  - INDIVIDUAL
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/roles/add':
     post:
       summary: Add a role to a user
@@ -2984,22 +4798,42 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: Role added
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/roles/remove':
     post:
       summary: Remove a role from a user
@@ -3032,26 +4866,50 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: Role removed
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
-          description: 'Not Found: User cannot be found'
+          description: 'Not Found: User cannot be found.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. User cannot be found. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/app/entitlement/list':
     get:
       summary: Get the list of application entitlements for this user
@@ -3078,22 +4936,58 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/UserAppEntitlementList'
+          examples:
+            application/json:
+              - appId: djApp
+                appName: Dow Jones
+                listed: true
+                install: false
+              - appId: selerity
+                appName: Selerity Context
+                listed: true
+                install: true
+                products:
+                  - appId: selerity
+                    name: Standard
+                    subscribed: true
+                    type: default
+                  - appId: selerity
+                    name: Premium
+                    sku: AcDccU53SsY
+                    subscribed: false
+                    type: premium
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
     post:
       summary: Update the application entitlements for this user
       consumes:
@@ -3124,22 +5018,58 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/UserAppEntitlementList'
+          examples:
+            application/json:
+              - appId: djApp
+                appName: Dow Jones
+                listed: true
+                install: false
+              - appId: selerity
+                appName: Selerity Context
+                listed: true
+                install: true
+                products:
+                  - appId: selerity
+                    name: Standard
+                    subscribed: true
+                    type: default
+                  - appId: selerity
+                    name: Premium
+                    sku: AcDccU53SsY
+                    subscribed: false
+                    type: premium
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
     patch:
       summary: Update unique entitlement of an app for this user. Entitlement can be installation, visibility or product
       consumes:
@@ -3170,22 +5100,58 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/UserAppEntitlementList'
+          examples:
+            application/json:
+              - appId: djApp
+                appName: Dow Jones
+                listed: true
+                install: false
+              - appId: selerity
+                appName: Selerity Context
+                listed: true
+                install: true
+                products:
+                  - appId: selerity
+                    name: Standard
+                    subscribed: true
+                    type: default
+                  - appId: selerity
+                    name: Premium
+                    sku: AcDccU53SsY
+                    subscribed: false
+                    type: premium
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/avatar':
     get:
       summary: Get the URL of the avatar of a particular user
@@ -3213,22 +5179,44 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/AvatarList'
+          examples:
+            application/json:
+              - size: original
+                url: ../avatars/izcQTdRVFOK_qhCrYeQOpIuHKuZuMk3J88Uz_bShzM8.png
+              - size: small
+                url: ../avatars/izcQTdRVFOK_qhCrYeQOpIuHKuZuMk3J88Uz_bShzM8_small.png
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/avatar/update':
     post:
       summary: Update the avatar of a particular user
@@ -3261,22 +5249,42 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: OK
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/disclaimer':
     get:
       summary: Get the disclaimer assigned to a user
@@ -3304,24 +5312,50 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/Disclaimer'
+          examples:
+            application/json:
+              id: 571d2052e4b042aaf06d2e7a
+              name: Enterprise Disclaimer
+              content: This is a disclaimer for the enterprise.
+              frequencyInHours: 24
+              isDefault: false
+              isActive: true
+              createdDate: 1461526610846
+              modifiedDate: 1461526610846
         '204':
           description: No content. User doesn't have an assigned disclaimer
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
     delete:
       summary: Unassign a disclaimer from a user
       consumes:
@@ -3345,25 +5379,45 @@ paths:
         - User
       responses:
         '200':
-         description: Success
-         schema:
-           $ref: '#/definitions/SuccessResponse'
+          description: Success
+          schema:
+            $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: OK
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/disclaimer/update':
     post:
       summary: Assign a disclaimer to a user
@@ -3396,22 +5450,42 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: OK
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/delegates':
     get:
       summary: Get the delegates assigned to a user
@@ -3439,22 +5513,41 @@ paths:
           description: The userid's of the delegates of this user.
           schema:
             $ref: '#/definitions/IntegerList'
+          examples:
+            application/json:
+              - 7215545078461
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/delegates/update':
     post:
       summary: Update the delegates assigned to a user
@@ -3487,22 +5580,42 @@ paths:
           description: Sucesss.
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: Added delegate [7215545078461] for account [7215545078541]
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/features':
     get:
       summary: Get the list of Symphony feature entitlements enabled for a particular user
@@ -3530,22 +5643,52 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/FeatureList'
+          examples:
+            application/json:
+              - entitlment: canCreatePublicRoom
+                enabled: true
+              - entitlment: isExternalRoomEnabled
+                enabled: false
+              - entitlment: delegatesEnabled
+                enabled: true
+              - entitlment: isExternalIMEnabled
+                enabled: true
+              - entitlment: sendFilesEnabled
+                enabled: true
+              - entitlment: canUpdateAvatar
+                enabled: true
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/features/update':
     post:
       summary: Update the list of Symphony feature entitlements for a particular user
@@ -3578,22 +5721,42 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: OK
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/user/{uid}/follow':
     post:
       summary: Make a list of users start following a specific user
@@ -3626,22 +5789,42 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: User(s) successfully added in the list of followers
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/user/{uid}/unfollow':
     post:
       summary: Make a list of users unfollowing a specific user
@@ -3674,22 +5857,42 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: User(s) successfully removed from the list of followers
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/user/{uid}/followers':
     get:
       summary: Returns the list of followers for a specific user
@@ -3729,22 +5932,49 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/FollowersListResponse'
+          examples:
+            application/json:
+              count: 5
+              followers:
+                - 13056700579848
+                - 13056700580889
+                - 13056700580890
+              pagination:
+                cursors:
+                  before: 1
+                  after: 4
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/user/{uid}/following':
     get:
       summary: Returns the list of users that a specific user is following
@@ -3784,22 +6014,47 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/FollowingListResponse'
+          examples:
+            application/json:
+              count: 3
+              followers:
+                - 13056700580888
+                - 13056700580889
+              pagination:
+                cursors:
+                  before: 1
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/user/manifest/own':
     post:
       summary: Update own service account manifest
@@ -3828,18 +6083,34 @@ paths:
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
     get:
       summary: Get own service account manifest
       produces:
@@ -3861,18 +6132,34 @@ paths:
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/status':
     get:
       summary: Get the status, active or inactive, for a particular user
@@ -3900,22 +6187,41 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/UserStatus'
+          examples:
+            application/json:
+              status: ENABLED
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{uid}/status/update':
     post:
       summary: Update the status of a particular user
@@ -3948,22 +6254,41 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              message: OK
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/admin/streams/list':
     post:
       summary: |
@@ -4000,22 +6325,108 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V2AdminStreamList'
+          examples:
+            application/json:
+              count: 4
+              skip: 0
+              limit: 50
+              filter:
+                streamTypes:
+                  -  
+              streams:
+                - id: Q2KYGm7JkljrgymMajYTJ3___qcLPr1UdA
+                  isExternal: false
+                  isActive: true
+                  isPublic: false
+                  type: ROOM
+                  attributes:
+                    roomName: Active Internal Private Room
+                    roomDescription: Active Internal Private Room
+                    createdByUserId: 8933531975689
+                    createdDate: 1481575056047
+                    lastModifiedDate: 1481575056047
+                    originCompany: Symphony
+                    originCompanyId: 130
+                    membersCount: 1
+                    lastMessageDate: 1516699467959 
+                - id: _KnoYrMkhEn3H2_8vE0kl3___qb5SANQdA
+                  isExternal: true
+                  isActive: false
+                  isPublic: false
+                  type: ROOM
+                  attributes:
+                    roomName: Inactive External Room
+                    roomDescription: Inactive External Room
+                    createdByUserId: 8933531975686
+                    createdDate: 1481876438194
+                    lastModifiedDate: 1481876438194
+                    originCompany: Symphony
+                    originCompanyId: 130
+                    membersCount: 2
+                    lastMessageDate: 1516699467959 
+                - id: fBoaBSRUyb5Rq3YgeSqZvX___qbf5IAhdA
+                  isExternal: false
+                  isActive: true
+                  type: IM
+                  attributes:
+                    members:
+                      - 8933531975686
+                      - 8933531975689
+                    createdByUserId: 8933531975689
+                    createdDate: 1482302390238
+                    lastModifiedDate: 1482302390238
+                    originCompany: Symphony
+                    originCompanyId: 130
+                    membersCount: 2
+                    lastMessageDate: 1516699467959 
+                - id: k19u9c3GSE_iq0VHDKe1on___qa0Cp2WdA
+                  isExternal: false
+                  isActive: true
+                  type: MIM
+                  attributes:
+                    members:
+                      - 8933531975688
+                      - 8933531975689
+                      - 8933531975717
+                    createdByUserId: 8933531975688
+                    createdDate: 1483038089833
+                    lastModifiedDate: 1483038089833
+                    originCompany: Symphony
+                    originCompanyId: 130
+                    membersCount: 3
+                    lastMessageDate: 1516699467959
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/stream/{id}/membership/list':
     get:
       summary: List the current members of an existing stream.  The stream can be of type IM, MIM, or ROOM
@@ -4049,22 +6460,80 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/V2MembershipList'
+          examples:
+            application/json:
+              count: 3
+              skip: 0
+              limit: 32
+              members:
+                - user:
+                    userId: 13537736917000
+                    email: john.doe@symphony.com
+                    firstName: John
+                    lastName: Doe
+                    displayName: John Doe
+                    company: pod197
+                    companyId: 197
+                    isExternal: false
+                  isOwner: true
+                  isCreator: true
+                  joinDate: 1604494574047
+                - user:
+                    userId: 13606456393736
+                    email: alice.smith@pod198.com
+                    firstName: Alice
+                    lastName: Smith
+                    displayName: Alice Smith
+                    company: pod198
+                    companyId: 198
+                    isExternal: true
+                  isOwner: false
+                  isCreator: false
+                  joinDate: 1604494722469
+                - user:
+                    userId: 13537736917001
+                    email: bot@symphony.com
+                    displayName: User Provisioning Bot
+                    company: pod197
+                    companyId: 197
+                    isExternal: false
+                  isOwner: false
+                  isCreator: false
+                  joinDate: 1604494605272
+                  addedThroughGroups:
+                    - 68719476744
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/system/features/list':
     get:
       summary: Get the full set of Symphony features available for this pod
@@ -4085,22 +6554,43 @@ paths:
           description: The list of valid feature entitlement names.
           schema:
             $ref: '#/definitions/StringList'
+          examples:
+            application/json:
+              - postReadEnabled
+              - canCreatePublicRoom
+              - canJoinMultiLateralRoom
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/system/protocols/list':
     get:
       summary: Get a list of all URI protocols supported by the company (pod)
@@ -4125,18 +6615,34 @@ paths:
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/system/protocols':
     get:
       summary: Get a list of URI protocols supported by the company (pod)
@@ -4167,22 +6673,43 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/StringList'
+          examples:
+            application/json:
+              - ftp
+              - mailto
+              - skype
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/system/protocols':
     post:
       summary: Add an entry to URI protocols supported by the company (pod)
@@ -4209,22 +6736,41 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/Protocol'
+          examples:
+            application/json:
+              scheme: skype
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/system/protocols/{scheme}':
     delete:
       summary: Remove an entry from URI protocols supported by the company (pod)
@@ -4252,18 +6798,34 @@ paths:
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/system/roles/list':
     get:
       summary: Get a list of all roles available in the company (pod)
@@ -4284,22 +6846,56 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/RoleDetailList'
+          examples:
+            application/json:
+              - id: CONTENT_MANAGEMENT
+                name: Content Management
+                userTypes:
+                  - SYSTEM
+                  - NORMAL
+                optionalActions:
+                  - MONITOR_ROOMS
+              - id: COMPLIANCE_OFFICER
+                name: Compliance Officer
+                userTypes:
+                  - NORMAL
+                optionalActions:
+                  - BAN_AND_UNBAN_ROOM_MEMBER
+                  - LOCK_AND_UNLOCK_ROOM
+                  - MONITOR_ROOMS
+                  - MONITOR_WALL_POSTS
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/message/{mid}/status':
     get:
       summary: Get the read status of a particular message.
@@ -4323,26 +6919,87 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/MessageStatus'
+          examples:
+            application/json:
+              author: 
+                userId: 7078106103901
+                firstName: Gustav
+                lastName: Mahler
+                displayName: Gustav Mahler
+                email: gustav.mahler@music.org
+                userName: gmahler
+                timestamp: 1531968487845
+              read:
+                - userId: 7078106103901 
+                  firsName: Gustav 
+                  lastName: Mahler 
+                  displayName: Gustav Mahler 
+                  email: gustav.mahler@music.org 
+                  userName: gmahler 
+                  timestamp: 1489769156271
+                - userId: 7078106103902 
+                  firsName: Hildegard 
+                  lastName: Bingen 
+                  displayName: Hildegard Bingen 
+                  email: hildegard.bingen@music.org 
+                  userName: hbingen 
+                  timestamp: 1487352923000
+              delivered:
+                - userId: 7078106103903 
+                  firsName: Franz 
+                  lastName: Liszt 
+                  displayName: Franz Liszt 
+                  email: franz.liszt@music.org 
+                  userName: fliszt 
+                  timestamp: 1484674523000
+              sent:
+                - userId: 7078106103904 
+                  firsName: Benjamin 
+                  lastName: Britten 
+                  displayName: Benjamin Britten 
+                  email: benjamin.britten@music.org 
+                  userName: bbritten 
+                  timestamp: 1484156123000
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
-          description: 'Not found: The informed Message ID does not exist'
+          description: 'Not Found: Message ID does not exist.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. Message ID does not exist. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/app/create':
     post:
       summary: Creates a new app
@@ -4369,22 +7026,61 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/ApplicationDetail'
+          examples:
+            application/json:
+              applicationInfo:
+                appId: my-test-app
+                name: my-test-app
+                appUrl: https://joe.mydomain.com
+                domain: mydomain.com
+                publisher: Joe Smith
+              description: a test app
+              allowOrigins: mydomain.com
+              permissions:
+                - ACT_AS_USER
+                - SEND_MESSAGES
+              notification:
+                url: https://some.url
+                apiKey: 123456
+              cert: -----BEGIN PUBLIC KEY-----\nMIICIANBgkqhw0BAQ...cCAwEAAQ==\n-----END PUBLIC KEY-----
+              authenticationKeys: null
+              properties:
+                - key: port
+                  value: 4000
+                - key: url
+                  value: https://someother.url
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/app/{id}/update':
     post:
       summary: Updates a app
@@ -4416,22 +7112,61 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/ApplicationDetail'
+          examples:
+            application/json:
+              applicationInfo:
+                appId: my-test-app
+                name: my-test-app
+                appUrl: https://joe.mydomain.com
+                domain: mydomain.com
+                publisher: Joe Smith
+              description: a test app
+              allowOrigins: mydomain.com
+              permissions:
+                - ACT_AS_USER
+                - SEND_MESSAGES
+              notification:
+                url: https://some.url
+                apiKey: 123456
+              cert: -----BEGIN PUBLIC KEY-----\nMIICIANBgkqhw0BAQ...cCAwEAAQ==\n-----END PUBLIC KEY-----
+              authenticationKeys: null
+              properties:
+                - key: port
+                  value: 4000
+                - key: url
+                  value: https://someother.url
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/app/{id}/delete':
     post:
       summary: Deletes a app
@@ -4457,22 +7192,42 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: OK
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/app/{id}/get':
     get:
       summary: Gets a app
@@ -4498,22 +7253,61 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/ApplicationDetail'
+          examples:
+            application/json:
+              applicationInfo:
+                appId: my-test-app
+                name: my-test-app
+                appUrl: https://joe.mydomain.com
+                domain: mydomain.com
+                publisher: Joe Smith
+              description: a test app
+              allowOrigins: mydomain.com
+              permissions:
+                - ACT_AS_USER
+                - SEND_MESSAGES
+              notification:
+                url: https://some.url
+                apiKey: 123456
+              cert: -----BEGIN PUBLIC KEY-----\nMIICIANBgkqhw0BAQ...cCAwEAAQ==\n-----END PUBLIC KEY-----
+              authenticationKeys: null
+              properties:
+                - key: port
+                  value: 4000
+                - key: url
+                  value: https://someother.url
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   /v1/admin/messages:
     post:
       summary: Fetch message details
@@ -4539,29 +7333,53 @@ paths:
           schema:
             $ref: '#/definitions/MessageDetails'
         '400':
-          description: 'Client error.'
+          description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
-          description: 'Not found: Message ID could not be found.'
+          description: 'Not Found: Message ID could not be found.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. Message ID could not be found. See response body for fruther details.
         '422':
           description: 'Unprocessable entity: Invalid message type.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 422
+              message: // Unprocessable Entity. Invalid message type. See response body for further details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/admin/user/create':
     post:
       summary: Create a new V2 User
@@ -4587,22 +7405,74 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/V2UserDetail'
+          examples:
+            application/json:
+              userAttributes:
+                emailAddress: johndoe@symphony.com
+                firstName: John
+                lastName: Doe
+                userName: johndoe
+                displayName: John Doe
+                companyName: Company
+                department: Departament
+                division: Division
+                title: Junior Trader
+                twoFactorAuthPhone: "+15419999999"
+                workPhoneNumber: "+15419999999"
+                mobilePhoneNumber: "+15419999999"
+                accountType: NORMAL
+                location: New York
+                jobFunction: Trader
+                assetClasses:
+                  - Equities
+                industries:
+                  - Healthcare
+                  - Technology
+              userSystemInfo:
+                id: 7215545078461
+                status: ENABLED
+                suspended: true
+                suspensionReason: The user will be OOO due to a mandatory leave
+                suspendedUntil: 1601546400
+                createdDate: 1461508270000
+                createdBy: "7215545057281"
+                lastUpdatedDate: 1461508270000
+                lastLoginDate: 1461508270000
+                deactivatedDate: 1461508270000
+              roles:
+                - INDIVIDUAL
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/admin/user/{uid}/update':
     post:
       summary: Update an existing V2 User
@@ -4635,25 +7505,77 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/V2UserDetail'
+          examples:
+            application/json:
+              userAttributes:
+                emailAddress: johndoe@symphony.com
+                firstName: John
+                lastName: Doe
+                userName: johndoe
+                displayName: John Doe
+                companyName: Company
+                department: Departament
+                division: Division
+                title: Junior Trader
+                twoFactorAuthPhone: "+15419999999"
+                workPhoneNumber: "+15419999999"
+                mobilePhoneNumber: "+15419999999"
+                accountType: NORMAL
+                location: New York
+                jobFunction: Trader
+                assetClasses:
+                  - Equities
+                industries:
+                  - Healthcare
+                  - Technology
+              userSystemInfo:
+                id: 7215545078461
+                status: ENABLED
+                suspended: true
+                suspensionReason: The user will be OOO due to a mandatory leave
+                suspendedUntil: 1601546400
+                createdDate: 1461508270000
+                createdBy: "7215545057281"
+                lastUpdatedDate: 1461508270000
+                lastLoginDate: 1461508270000
+                deactivatedDate: 1461508270000
+              roles:
+                - INDIVIDUAL
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v2/admin/user/{uid}':
     get:
-      summary: Retreive V2 User details for a particular user
+      summary: Retrieve V2 User details for a particular user
       consumes:
         - application/json
       produces:
@@ -4678,22 +7600,74 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/V2UserDetail'
+          examples:
+            application/json:
+              userAttributes:
+                emailAddress: johndoe@symphony.com
+                firstName: John
+                lastName: Doe
+                userName: johndoe
+                displayName: John Doe
+                companyName: Company
+                department: Departament
+                division: Division
+                title: Junior Trader
+                twoFactorAuthPhone: "+15419999999"
+                workPhoneNumber: "+15419999999"
+                mobilePhoneNumber: "+15419999999"
+                accountType: NORMAL
+                location: New York
+                jobFunction: Trader
+                assetClasses:
+                  - Equities
+                industries:
+                  - Healthcare
+                  - Technology
+              userSystemInfo:
+                id: 7215545078461
+                status: ENABLED
+                suspended: true
+                suspensionReason: The user will be OOO due to a mandatory leave
+                suspendedUntil: 1601546400
+                createdDate: 1461508270000
+                createdBy: "7215545057281"
+                lastUpdatedDate: 1461508270000
+                lastLoginDate: 1461508270000
+                deactivatedDate: 1461508270000
+              roles:
+                - INDIVIDUAL
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/files/allowedTypes':
     get:
       summary: Get supported attachment types for the pod
@@ -4712,22 +7686,44 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/StringList'
+          examples:
+            application/json:
+              - .bmp
+              - .doc
+              - .png
+              - .mp4
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/file_ext/v1/allowed_extensions':
     get:
       consumes:
@@ -4928,26 +7924,75 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/MessageReceiptDetailResponse'
+          examples:
+            application/json:
+              creator:
+                id: 7215545058329
+                name: User Test
+              stream:
+                id: lFpyw0ATFmji+Cc/cSzbk3///pZkWpe1dA==
+                name: Test Room
+                streamType: ROOM
+              creationDate: 1552999333141
+              deliveryReceiptCount: 1
+              readReceiptCount: 1
+              emailNotificationCount: 1
+              downloadReceiptCounts:
+                - fileName: internal_7078106
+                  count: 1
+              MessageReceiptDetail:
+                - user:
+                    id: 7215545058313
+                    username: dpayet
+                    firstName: Dimitiri
+                    lastName: Payet
+                    emailAddress: dpayet@om.fr
+                  deliveryReceiptTimestamp: 1552999333784
+                  readReceiptTimestamp: 1552999335114
+                  emailNotificationTimestamp: 1552999335114
+                  downloadReceiptCounts:
+                    - fileName: Untitled Document.txt
+                      timestamp: 1552999335740
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '404':
           description: 'Not Found: Message receipt details cannot be found.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: // Not Found. Message receipt details cannot be found. See response body for fruther details.
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/languages':
     get:
       summary: Lists available languages for the pod.
@@ -4994,18 +8039,34 @@ paths:
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
   '/v1/admin/user/{userId}/suspension/update':
     put:
       summary: Update the status of suspension of a particular user
@@ -5037,22 +8098,42 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/SuccessResponse'
+          examples:
+            application/json:
+              format: TEXT
+              message: User suspended with success
         '400':
           description: 'Client error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 400
+              message: // Client error, see response body for further details.
         '401':
           description: 'Unauthorized: Session tokens invalid.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 401
+              message: Invalid session
         '403':
           description: 'Forbidden: Caller lacks necessary entitlement.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 403
+              message: The user lacks the required entitlement to perform this operation
         '500':
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              code: 500
+              message: // Server error, see response body for further details.
 
 definitions:
   Error:
@@ -5061,14 +8142,17 @@ definitions:
       code:
         type: integer
         format: int32
+        example: 401
       message:
         type: string
+        example: Invalid session
   CompanyCert:
       type: object
       properties:
         pem:
           type: string
           description: An X509 certificate in PEM format
+          example: -----BEGIN CERTIFICATE-----MIIH/TC...p9DBiB/-----END CERTIFICATE-----
         attributes:
           $ref: '#/definitions/CompanyCertAttributes'
   CompanyCertDetail:
@@ -5089,6 +8173,20 @@ definitions:
           $ref: '#/definitions/CompanyCertAttributes'
         companyCertInfo:
           $ref: '#/definitions/CompanyCertInfo'
+      example:
+        - companyCertAttributes:
+            name: agentservice
+            type:
+              type: USER
+            status:
+              type: TRUSTED
+          companyCertInfo:
+            fingerPrint: 300a...
+            lastSeen: 0
+            updatedAt: 0
+            updatedBy: 0
+            commonName: agentservice
+            expiryDate: 1781886755000
   CompanyCertType:
     type: object
     properties:
@@ -5099,6 +8197,7 @@ definitions:
           - USER
           - OPERATIONSSIGNING
           - OPERATIONSUSER
+        example: USER
   CompanyCertTypeList:
     type: array
     items:
@@ -5113,12 +8212,14 @@ definitions:
           - KNOWN
           - REVOKED
           - DISABLED
+        example: TRUSTED
   CompanyCertAttributes:
     type: object
     properties:
       name:
         type: string
         description: Friendly name assigned by administrator
+        example: agentservice
       type:
         $ref: '#/definitions/CompanyCertType'
       status:
@@ -5129,59 +8230,89 @@ definitions:
       fingerPrint:
         type: string
         description: Unique identifier
+        example: 300a...
       issuerFingerPrint:
         type: string
         description: Unique identifier of issuer cert if known
+        example: 450s...
       lastSeen:
         type: integer
         format: int64
         description: Date when we last saw this certificate presented
+        example: 0
       updatedAt:
         type: integer
         format: int64
         description: Date when this cert was last updated by administrator
+        example: 0
       updatedBy:
         type: integer
         format: int64
         description: User ID of administrator who last updated this cert
+        example: 0
       commonName:
         type: string
         description: The Symphony account name which this certificate authenticates
+        example: agentservice
       expiryDate:
         type: integer
         format: int64
         description: Expiry date of this cert
+        example: 1781886755000
   CertInfo:
     type: array
     items:
       $ref: '#/definitions/CertInfoItem'
+    example:
+      - name: Validity
+        attributes:
+          - name: Not Before
+            value: Mon Jan 15 20:56:05 UTC 2018
+          - name: Not After
+            value: Thu Jan 15 20:56:05 UTC 2026
+      - name: Public Key
+        attributes:
+          - name: Algorithm
+            value: RSA
+          - name: Format
+            value: X.509
   CertInfoItem:
     type: object
     properties:
       name:
         type: string
+        example: Public Key
       attributes:
         type: array
         items:
           $ref: '#/definitions/NameValuePair'
+        example:
+          - name: Algorithm
+            value: RSA
+          - name: Format
+            value: X.509
   PodCertificate:
     type: object
     properties:
       certificate:
         description: Certificate in PEM format
         type: string
+        example: PEM_CERTIFICATE
   NameValuePair:
     type: object
     properties:
       name:
         type: string
+        example: Algorithm
       value:
         type: string
+        example: RSA
   Stream:
     type: object
     properties:
       id:
         type: string
+        example: xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA
   UserError:
     description: User error information
     type: object
@@ -5189,12 +8320,15 @@ definitions:
       error:
         type: string
         description: 'Error code informing what is wrong'
+        example: invalid.format
       email:
         type: string
         description: 'Email with error. Only one of the following fields should be present: email or id'
+        example: notavalidemail
       id:
         type: string
         description: 'Id with error. Only one of the following fields should be present: email or id'
+        example: notavalidid
   UserV2:
     description: User record version 2
     type: object
@@ -5202,46 +8336,64 @@ definitions:
       id:
         type: integer
         format: int64
+        example: 7696581394433
       emailAddress:
         type: string
         format: email
+        example: admin@symphony.com
       firstName:
         type: string
+        example: Symphony
       lastName:
         type: string
+        example: Admin
       displayName:
         type: string
+        example: Symphony Admin
       title:
         type: string
+        example: Administrator
       company:
         type: string
+        example: Acme
       username:
         type: string
+        example: admin@symphony.com
       location:
         type : string
+        example: California
       accountType:
         type: string
         enum: [NORMAL, SYSTEM, SDL]
+        example: NORMAL
       avatars:
         # avatar urls for both original size and small size
         $ref: '#/definitions/AvatarList'
       workPhoneNumber:
         type: string
         description: 'Note: only available if the application has the extended user or contact permission'
+        example: "+33901020304"
       mobilePhoneNumber:
         type: string
         description: 'Note: only available if the application has the extended user or contact permission'
+        example: "+33601020304"
       jobFunction:
         type: string
         description: 'Note: only available if the application has the extended user or contact permission'
+        example: Sales
       department:
         type: string
         description: 'Note: only available if the application has the extended user or contact permission'
+        example: APIs
       division:
         type: string
         description: 'Note: only available if the application has the extended user or contact permission'
+        example: Partnerships
       roles:
         $ref: '#/definitions/StringList'
+        example:
+          - INDIVIDUAL
+          - SUPER_ADMINISTRATOR
   V2UserList:
     description: List of User record version 2
     type: object
@@ -5251,11 +8403,50 @@ definitions:
         items:
           $ref: '#/definitions/UserV2'
         description: 'List of all users found with the search'
+        example:
+          - id: 15942919536460
+            emailAddress: technicalwriter@symphony.com
+            firstName: Technical
+            lastName: Writer
+            displayName: Technical Writer
+            title: Technical Writer
+            company: Symphony
+            department: Marketing // if internal user
+            username: tw
+            accountType: NORMAL 
+            location: France // if internal user
+            mobilePhoneNumber: +33601020304
+            avatars:
+              - size: original
+                url: ../avatars/static/150/default.png
+              - size: small
+                url: ../avatars/static/50/default.png
+          - id: 15942919536461
+            emailAddress: serviceaccount@symphony.com
+            firstName: null
+            lastName: null
+            displayName: Service Account
+            title: null
+            company: pod232
+            department: Marketing // if internal user
+            username: SA
+            location: France // if internal user
+            accountType: SYSTEM
+            avatars:
+              - size: original
+                url: ../avatars/static/150/default.png
+              - size: small
+                url: ../avatars/static/50/default.png
       errors:
         type: array
         items:
           $ref: '#/definitions/UserError'
         description: 'List of all errors found with the informed search criteria'
+        example:
+          - error: invalid.format
+            email: notavalidemail
+          - error: invalid.format
+            id: 654321
   UserSearchResults:
     type: object
     properties:
@@ -5263,14 +8454,17 @@ definitions:
         description: The total number of users which matched the search criteria.
         type: integer
         format: int64
+        example: 1
       skip:
         description: The number of skipped results.
         type: integer
         format: int64
+        example: 0
       limit:
         description: The number of returned results.
         type: integer
         format: int64
+        example: 1
       searchQuery:
         # The search query that produced this result.
         $ref: '#/definitions/UserSearchQuery'
@@ -5279,39 +8473,50 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/UserV2'
+        example:
+          -
   UserSearchFilter:
     type: object
     properties:
       accountTypes:
         $ref: '#/definitions/StringList'
         description: type of user used to search
+        example: NORMAL
       title:
         type: string
         description: user's job title
+        example: Sales Manager
       company:
         type: string
         description: company name
+        example: Symphony
       location:
         type: string
         description: city of the user's job location
+        example: Marseille
       marketCoverage:
         type: string
         description: geographic area the user works with
+        example: EMEA
       responsibility:
         type: string
         description: user's responsibility
+        example: BAU
       function:
         type: string
         description: user's function
+        example: Trade Management
       instrument:
         type: string
         description: higher level instrument for the Asset Classes
+        example: Securities
   UserSearchQuery:
     type: object
     properties:
       query:
         type: string
         description: search / query term.  This can be firstname, lastname, displayname or email
+        example: jane
       filters:
         # query filters
         $ref: '#/definitions/UserSearchFilter'
@@ -5325,22 +8530,28 @@ definitions:
     properties:
       username:
         type: string
+        example: dpayet
   UserIdList:
     type: array
     items:
         type: integer
         format: int64
+    example:
+      - 7215545058313
+      - 7215545078461
   UserId:
     type: object
     properties:
       id:
         type: integer
         format: int64
+        example: 7215545058313
   StringId:
     type: object
     properties:
       id:
         type: string
+        example: xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA
   RoomAttributes:
     type: object
     properties:
@@ -5362,68 +8573,91 @@ definitions:
       name:
         type: string
         description: Room name.
+        example: API room
       keywords:
         type: array
         description: Keywords for search to use to find this room
         items:
           $ref: '#/definitions/RoomTag'
+        example:
+          - key: region
+            value: EMEA
+          - key: lead
+            value: Daffy Duck
       description:
         type: string
         description: Room description.
+        example: Created via the API
       membersCanInvite:
         type: boolean
         description: If true, any chatroom participant can add new participants. If false, only owners can add new participants.
+        example: true
       discoverable:
         type: boolean
         description: If true, this chatroom (name, description and messages) can be searched and listed by non-participants. If false, only participants can search this room.
+        example: false
       public:
         type: boolean
         description: If true, this is a public chatroom. IF false, a private chatroom.
+        example: false
       readOnly:
         type: boolean
         description: If true, only stream owners can send messages.
+        example: false
       copyProtected:
         type: boolean
         description: If true, clients disable the clipboard copy for content in this stream.
+        example: false
       crossPod:
         type: boolean
         description: If true, this room is a cross pod room
+        example: false
       viewHistory:
         type: boolean
         description: If true, new members can view the room chat history of the room.
+        example: false
       multiLateralRoom:
         type: boolean
         description: If true, this is a multi lateral room where we can find users belonging to more than 2 companies.
+        example: false
       scheduledMeeting:
         type: boolean
         description: If true, this room is for a scheduled meeting.
+        example: false
       subType:
         type: string
         description: This field is ignored when creating a new room as it was only used for email integration which is now sunset.
       pinnedMessageId:
         type: string
         description: UrlSafe message id of the pinned message inside the room. To perform unpin operation, send an empty string.
+        example: vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ
       groupChat:
         type: boolean
         description: "If true, this room is a group chat. Note: this parameter is ignored for creating rooms. Since SBE 20.16."
         x-since: 20.16
+        example: false
   RoomSearchCriteria:
     description: Room Query Object. Used to specify the parameters for room search.
     properties:
       query:
         description: The search query. Matches the room name and description.
         type: string
+        example: automobile
       labels:
         description: A list of room tag labels whose values will be queried.
         type: array
         items:
           type: string
+        example:
+          - industry
       active:
         description: Restrict the search to active/inactive rooms. If unspecified, search all rooms.
         type: boolean
+        example: true
       private:
         description: Restrict the search to private rooms. If unspecified, search all rooms.
         type: boolean
+        example: true
       owner:
         # Restrict the search to rooms owned by the specified user ID.
         $ref: '#/definitions/UserId'
@@ -5441,6 +8675,7 @@ definitions:
         enum:
           - BASIC
           - RELEVANCE
+        example: RELEVANCE
     required:
     - query
   V2RoomSearchCriteria:
@@ -5452,6 +8687,7 @@ definitions:
           subType:
             description: "Restrict the search to the specific room subtype. Valid values are: EMAIL"
             type: string
+            example: EMAIL
   V3RoomSearchResults:
     description: A list of search results and counts per search parameter.
     properties:
@@ -5459,12 +8695,15 @@ definitions:
         description: The total number of rooms matched by the search.
         type: integer
         format: int64
+        example: 2
       skip:
         description: The number of skipped results.
         type: integer
+        example: 0
       limit:
         description: The number of returned results.
         type: integer
+        example: 10
       query:
         # The search query that produced this result.
         $ref: '#/definitions/V2RoomSearchCriteria'
@@ -5473,20 +8712,59 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/V3RoomDetail'
+        example:
+          - roomAttributes:
+              name: Automobile Industry Room
+              description: Room to discuss car companies
+              membersCanInvite: true
+              readOnly: false
+              copyProtected: false
+              crossPod: false
+              viewHistory: false
+              public: false
+              multiLateralRoom: false
+            roomSystemInfo:
+              id: tzwvAZIdDMG3ZPRxv+xsgH///qr+JJkWdA==
+              creationDate: 1464615003895
+              createdByUserId: 7696581411197
+              active: true
+          - roomAttributes:
+              name: Tesla Room
+              keywords:
+                - key: industry
+                  value: automobile
+              description: Discussions on TSLA
+              membersCanInvite: true
+              readOnly: false
+              copyProtected: false
+              crossPod: false
+              viewHistory: false
+              public: false
+              multiLateralRoom: false
+            roomSystemInfo:
+              id: o6UkQ1TEmU0Tf/DHUlZrCH///qr+JQowdA==
+              creationDate: 1464614974947
+              createdByUserId: 7696581411197
+              active: true
       facetedMatchCount:
         description: Detailed counts of matched rooms per search criterion.
         type: array
         items:
           $ref: '#/definitions/FacetedMatchCount'
+        example:
+          - facet: industry
+            count: 1
   RoomTag:
     description: Room Tag object. A key:value pair describing additional properties of the room.
     properties:
       key:
         description: A unique label of the Tag.
         type: string
+        example: region
       value:
         description: The value of this Tag's label.
         type: string
+        example: EMEA
     required:
     - key
     - value
@@ -5504,16 +8782,20 @@ definitions:
     properties:
      id:
         type: string
+        example: bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA
      creationDate:
         type: integer
         format: int64
         description: The datetime when the stream was originally created. Milliseconds since Jan 1 1970.
+        example: 1547661232368
      createdByUserId:
         type: integer
         format: int64
+        example: 14362370637825
      active:
         type: boolean
         description: If false, no messages can be sent in this stream, and membership is locked.
+        example: true
   ImmutableRoomAttributes:
     type: object
     description: These attributes cannot be changed once the room has been created
@@ -5548,6 +8830,9 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/GroupItem'
+        example:
+          - id: 68719476744
+            addedBy: 68719476743
   GroupItem:
     type: object
     properties:
@@ -5555,10 +8840,12 @@ definitions:
         description: The ID of the added group (aka SDL).
         type: integer
         format: int64
+        example: 68719476744
       addedBy:
         description: The user ID who added the group to the room.
         type: integer
         format: int64
+        example: 68719476743
   SuccessResponse:
     type: object
     properties:
@@ -5567,27 +8854,37 @@ definitions:
         enum:
           - TEXT
           - XML
+        example: TEXT
       message:
         type: string
+        example: Success
   AvatarUpdate:
     type: object
     properties:
       image:
         description: Base64 encoded image. Original image must be less than 2MB.
         type: string
+        example: iVBORw0KGgoAAAANSUhEUgAAAJgAAAAoCAMAAAA11sNmAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAX1QTFRFAAAAVVVVZmZmc8bmd3d3jMyMmZmZ+cxA////VVVVZmZmc8bmd3d3jMyM8oCZ+cxA////VVVVZmZmc8bmd3d3jMyM////VVVVZmZmc8bmd3d3jMyMmZmZ8oCZ+cxA////ZmZmjMyM////VVVVd3d3jMyM+cxA////VVVVZmZmc8bmd3d3jMyMmZmZnMyB8oCZ+cxA////ZmZmc8bmd3d3jMyMmZmZ+cxA////d3d3jMyM8oCZ+cxA////VVVVZmZmdm1RjMyM8oCZ+cxA////ZmZmmZmZ+cxA////W1tbZmZmc8bmdpGcd3d3jMyMmZmZ8oCZ////d3d3jMyMmZmZx3iJ+cxA////VVVVZmZmc8bmd3d3jMyMuIOVyqpG////VVVVZmZmbW1td3d3jMyMmZmZ+cxA////VVVVX1xUZmZmb46ac8bmdZ+vd3d3fnNQjMyMkpeGlqaWmJyYmZmZnYlMp5FLsZhJvJ9Iz3qM0K5F78VB8oCZ+cxA////9laq9wAAAGh0Uk5TABAQEBAQEBAQICAgICAgICAwMDAwMDBAQEBAQEBAQEBQUFBgYGBgYHBwcHBwcHBwcHCAgICAgICAj4+Pj4+fn5+fn5+fr6+vr7+/v7+/v7+/v8/Pz8/Pz9/f39/f39/f7+/v7+/v7+/qia/hAAADQ0lEQVRYw+2Xa1fTQBCGV0WJCBIvxEq10YoEVNQoaLxURKNWUHRRqYgaUSC1QkWsNzT7252Z3W1TWpCjX+I5fT/ksrM782T2Tc4JYy211NL/oJ50Ot2TRLD5FdTkma6kgU2uSB1PGtiY5HqZuK0ckWAjiQNLS7CdiQPrIq6xpGHtGnr0eRXA0gnjGlqoVCoA9kTe9rfXQob1r8ntv1mUmjlGYBUJdhJv2u9FlzWVHwohAt9kBuc+Dfk8zxjnWRnn3GHM4lKuAUM5nsMIjNETOQVM4NJstQpCzKxL10TjpdJ4B5zvEtg8Wj+zGEVRtwxjVpLFckIAA8sKAVWECBGCeUJ40BI9qwCDXHBqkxDYKT8WwVWWDDFMh5QOpWtURwk0dwE8toBgV2HoeoQ6T2GL6rJsAZ7OCBAGjgUqIbAvptBgNggo/XVgMJQ3mZmHk1wVGArMCPEajrxpwwZLpJkUO4JgXax7mriiaaay1xyWRQhPjsgmAoQGk9uCVeJg1bo+TafW6enxdI26U1Ia3X6psjrJ+hcjJQpjRwLOPYf2DZ7blp2iEhxz14FxCRZ4IB/BbLlflMjDVQVsqprOKZ3HNrKY0tzg09Wzt4Ho59r3NThlKO6E0iLkDTNUe4EloLAb4FGCIUuebrg2HIB5ihgXEJgNZI4Ci6XbDKxUevvp9bcvH98Xi8WvVTAo6no5yBbgtSt0B6AEAoRGM/PXOuZUd0qDgUeFxnWFfEGaaX8q9eyH0qsP998USTczmUx7/BPkqlSByOs6NrwY8EJpMPxa+E51P5XHTL1VLj0RDlm0B6w+XVPd+kV6fHRieWrbwHMEO6FjDr5TMTCuLYElctjGOo+x9WC4r0hrh9RyGsrWwPhGDiOdk1js4tJy+Qpjh24Ui/t0LIceJ/PkG8GM0P4jGPqogFYILQ2GxtsS2F7CYoeXAKzcCwO7B2rBrPrCcqMRrOadjcHgCy/NZ8VW+VsDY9cAi+14QWDv2tZHLcfzXP2tsWxTvRK2oS9gxLBjHrZsmm3oKZbreVbdqur0arpNtGeCwMoPk/czcuDUAwArn07gf9IwgpUPJhVsqi2hYLOdiQSb7Uugx3qH+zpZSy211FJNvwFNoXAncdBvawAAAABJRU5ErkJggg==
   Avatar:
     type: object
     properties:
       size:
         description: 'The Avatar Size'
         type: string
+        example: original
       url:
         description: 'Url of the image'
         type: string
+        example: ../avatars/izcQTdRVFOK_qhCrYeQOpIuHKuZuMk3J88Uz_bShzM8.png
   AvatarList:
     type: array
     items:
      $ref: '#/definitions/Avatar'
+    example:
+      - size: original
+        url: ../avatars/izcQTdRVFOK_qhCrYeQOpIuHKuZuMk3J88Uz_bShzM8.png
+      - size: small
+        url: ../avatars/izcQTdRVFOK_qhCrYeQOpIuHKuZuMk3J88Uz_bShzM8_small.png
   UserStatus:
     type: object
     properties:
@@ -5596,19 +8893,23 @@ definitions:
         enum:
           - ENABLED
           - DISABLED
+        example: ENABLED
       suspended:
         type: boolean
         description: An optional attribute indicating whether the user is temporarily suspended or not. Since SBE 20.14.
         x-since: 20.14
+        example: true
       suspendedUntil:
         type: integer
         format: int64
         description: An optional unix timestamp until which the suspension is effective. Since SBE 20.14.
         x-since: 20.14
+        example: 1601546400
       suspensionReason:
         type: string
         description: An optional description of the suspension reason. Since SBE 20.14.
         x-since: 20.14
+        example: The user will be OOO due to a mandatory leave
   UserFilter:
     type: object
     properties:
@@ -5630,42 +8931,60 @@ definitions:
         type: string
         enum:
           - EMAIL
+        example: EMAIL
   FeatureList:
     type: array
     items:
      $ref: '#/definitions/Feature'
+    example:
+      - entitlment: canCreatePublicRoom
+        enabled: true
+      - entitlment: isExternalRoomEnabled
+        enabled: false
+      - entitlment: canUpdateAvatar
+        enabled: true
   Feature:
     description: Entitlement feature record.
     type: object
     properties:
       entitlment:
         type: string
+        example: canCreatePublicRoom
       enabled:
         type: boolean
         description: Whether this entitlement is enabled for the user.
+        example: true
   Group:
     description: Information Barrier Group record.
     type: object
     properties:
       id:
         type: string
+        example: 571db1f2e4b027c4f055a594
       name:
         type: string
+        example: Group 1
       active:
         type: boolean
+        example: true
       memberCount:
         type: integer
         format: int32
+        example: 1
       policies:
         type: array
         items:
           type: string
+        example:
+         - 571db2e4e4b012df6341f393
       createdDate:
         type: integer
         format: int64
+        example: 1461563890135
       modifiedDate:
         type: integer
         format: int64
+        example: 1461563926812
   Product:
     description: Application Product
     type: object
@@ -5679,56 +8998,97 @@ definitions:
         description: App ID for the Product
         maxLength: 256
         minLength: 1
+        example: selerity
       name:
         type: string
         minLength: 1
         maxLength: 50
         description: Product Name
+        example: Premium
       sku:
         type: string
         minLength: 1
         maxLength: 100
         description: Product SKU
+        example: AcDccU53SsY
       subscribed:
         type: boolean
         description: indicate whether the product is subscribed or not
+        example: false
       type:
         type: string
         description: Product Type (default or premium)
+        example: premium
   ProductList:
     type: array
     items:
       $ref: '#/definitions/Product'
+    example:
+      - appId: selerity
+        name: Standard
+        subscribed: true
+        type: default
+      - appId: selerity
+        name: Premium
+        sku: AcDccU53SsY
+        subscribed: false
+        type: premium
   PolicyList:
     type: array
     items:
       $ref: '#/definitions/Policy'
+    example:
+      - id: 56e9df05e4b00737e3d3b82d
+        policyType: BLOCK
+        active: true
+        groups:
+          - 56e9def8e4b0b406041812e6
+          - 56e9deffe4b0b406041812e7
+        createdDate: 1458167557358
+        modifiedDate: 1458330606752
+      - id: 571cd64de4b042aaf06d2d8b
+        policyType: BLOCK
+        active: true
+        groups:
+          - 571cd646e4b042aaf06d2d84
+          - 571cd64ce4b042aaf06d2d8a
+        createdDate: 1461507661146
+        modifiedDate: 1461507661146
   Policy:
     description: Information Barrier Policy record.
     type: object
     properties:
       id:
         type: string
+        example: 56e9df05e4b00737e3d3b82d
       policyType:
         type: string
         enum:
           - BLOCK
           - ALLOW
+        example: BLOCK
       active:
         type: boolean
+        example: true
       memberCount:
         type: integer
         format: int32
+        example: 3
       groups:
         type: array
         items:
           type: string
+        example:
+          - 56e9deffe4b0b406041812e6
+          - 56e9deffe4b0b406041812e7
       createdDate:
         type: integer
         format: int64
+        example: 1458167557358
       modifiedDate:
         type: integer
         format: int64
+        example: 1458330606752
   UserAppEntitlement:
     description: Application Entitlements for the user
     type: object
@@ -5742,17 +9102,21 @@ definitions:
         description: Unique ID for the Application
         maxLength: 256
         minLength: 1
+        example: selerity
       appName:
         type: string
         description: Name for this Application
         maxLength: 50
         minLength: 1
+        example: Selerity Context
       listed:
         type: boolean
         description: if true, this application will be listed in the appstore for this user.  Otherwise, this application will be hidden in the appstore.
+        example: true
       install:
         type: boolean
         description: if true, it indicate this application is installed for this user.  Otherwise, this user does not have this application installed.
+        example: true
       products:
         $ref: '#/definitions/ProductList'
   PodAppEntitlement:
@@ -5770,19 +9134,24 @@ definitions:
         description: Unique ID for the Application
         maxLength: 256
         minLength: 1
+        example: djApp
       appName:
         type: string
         description: Name for this Application
         maxLength: 50
         minLength: 1
+        example: Dow Jones
       enable:
         type: boolean
+        example: true
       listed:
         type: boolean
         description: if true, this application will be listed in the appstore for everyone.  Otherwise, this application will be hidden in the appstore.
+        example: true
       install:
         type: boolean
         description: if true, the entitlement is set to automatic for the company.  Otherwise, it is set to manual.
+        example: true
   Role:
     description: Role record.
     type: object
@@ -5798,26 +9167,68 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/RoleDetail'
+    example:
+      - id: CONTENT_MANAGEMENT
+        name: Content Management
+        userTypes:
+          - SYSTEM
+          - NORMAL
+        optionalActions:
+          - MONITOR_ROOMS
+      - id: COMPLIANCE_OFFICER
+        name: Compliance Officer
+        userTypes:
+          - NORMAL
+        optionalActions:
+          - BAN_AND_UNBAN_ROOM_MEMBER
+          - LOCK_AND_UNLOCK_ROOM
+          - MONITOR_ROOMS
+          - MONITOR_WALL_POSTS
   RoleDetail:
     description: Role detailed.
     type: object
     properties:
       id:
         type: string
+        example: CONTENT_MANAGEMENT
       name:
         type: string
+        example: Content Management
       userTypes:
         type: array
         items:
           type: string
+        example:
+          - NORMAL
+          - SYSTEM
       optionalActions:
         type: array
         items:
           type: string
+        example:
+          - MONITOR_ROOMS
+          - MONITOR_WALL_POSTS
   GroupList:
     type: array
     items:
       $ref: '#/definitions/Group'
+    example:
+      - id: 571db1f2e4b027c4f055a594
+        name: Group 1
+        active: true
+        memberCount: 1
+        policies:
+          - 571db2e4e4b012df6341f393
+        createdDate: 1461563890135
+        modifiedDate: 1461563926812
+      - id: 571db20ae4b012df6341f391
+        name: Group 2
+        active: true
+        memberCount: 1
+        policies:
+          - 571db2e4e4b012df6341f393
+        createdDate: 1461563914581
+        modifiedDate: 1461564112286
   UserAppEntitlementsPatchList:
     description: Array of app entitlements to patch for a user
     type: array
@@ -5841,6 +9252,7 @@ definitions:
            * FALSE - The parameter should be set to false.
            * KEEP - The parameter should not be updated, the current value will be kept.
            * REMOVE - The parameter should be reverted to tenant level's value.
+        example: KEEP
   UserAppEntitlementPatch:
     description: Application Entitlements to patch for the user
     type: object
@@ -5852,26 +9264,59 @@ definitions:
         description: Unique ID for the Application
         maxLength: 256
         minLength: 1
+        example: selerity
       listed:
         type: string
         enum: *UserAppEntitlementPatchEnum
         default: KEEP
         description: If "TRUE", this application will be listed in the appstore for this user. If "FALSE", this application will be hidden in the appstore. If "KEEP" or not set, the current value is kept. If "REMOVE", it will be removed from user settings and the pod level setting's value will be used.
+        example: KEEP
       install:
         type: string
         enum: *UserAppEntitlementPatchEnum
         default: KEEP
         description: If "TRUE", this application will be installed for this user. If "FALSE", this application will not be installed for this user. If "KEEP" or not set, the current value is kept. If "REMOVE", it will be removed from user settings and the pod level setting's value will be used.
+        example: TRUE
       product:
         $ref: '#/definitions/Product'
   UserAppEntitlementList:
     type: array
     items:
       $ref: '#/definitions/UserAppEntitlement'
+    example:
+      - appId: djApp
+        appName: Dow Jones
+        listed: true
+        install: false
+      - appId: selerity
+        appName: Selerity Context
+        listed: true
+        install: true
+        products:
+          - appId: selerity
+            name: Standard
+            subscribed: true
+            type: default
+          - appId: selerity
+            name: Premium
+            sku: AcDccU53SsY
+            subscribed: false
+            type: premium
   PodAppEntitlementList:
     type: array
     items:
       $ref: '#/definitions/PodAppEntitlement'
+    example:
+      - appId: djApp
+        appName: Dow Jones
+        enable: true
+        listed: true
+        install: false
+      - appId: selerity
+        appName: Selerity Context
+        enable: false
+        listed: true
+        install: true
   RoleList:
     type: array
     items:
@@ -5881,52 +9326,88 @@ definitions:
     items:
         type: integer
         format: int64
+    example:
+      - 1461508270000
+      - 7215545057281
   StringList:
     type: array
     items:
         type: string
+    example:
+      - ftp
+      - mailto
+      - fdsup
+      - skype
   DisclaimerList:
     type: array
     items:
       $ref: '#/definitions/Disclaimer'
+    example:
+      - id: 571d2052e4b042aaf06d2e7a
+        name: Enterprise Disclaimer
+        content: This is a disclaimer for the enterprise.
+        frequencyInHours: 24
+        isDefault: false
+        isActive: true
+        createdDate: 1461526610846
+        modifiedDate: 1461526610846
+      - id: 571d20dae4b042aaf06d2e7c
+        name: New Enterprise Disclaimer
+        content: This is a second enterprise disclaimer.
+        frequencyInHours: 168
+        isDefault: false
+        isActive: true
+        createdDate: 1461526746875
+        modifiedDate: 1461526746875
   Disclaimer:
     type: object
     properties:
       id:
         type: string
+        example: 571d20dae4b042aaf06d2e7c
       name:
         type: string
+        example: New Enterprise Disclaimer
       content:
         type: string
+        example: This is a second enterprise disclaimer.
       frequencyInHours:
         type: integer
         format: int32
+        example: 168
       isDefault:
         type: boolean
+        example: false
       isActive:
         type: boolean
+        example: true
       createdDate:
         type: integer
         format: int64
+        example: 1461526746875
       modifiedDate:
         type: integer
         format: int64
+        example: 1461526746875
       format:
         type: string
         enum:
           - TEXT
           - XML
+        example: TEXT
   DelegateAction:
     type: object
     properties:
       userId:
         type: integer
         format: int64
+        example: 7215545078461
       action:
         type: string
         enum:
           - ADD
           - REMOVE
+        example: ADD
   UserInfo:
     description: User record.
     type: object
@@ -5941,46 +9422,66 @@ definitions:
     properties:
       emailAddress:
         type: string
+        example: janedoe@symphony.com
       firstName:
         type: string
+        example: Jane
       lastName:
         type: string
+        example: Doe
       userName:
         type: string
+        example: jane.doe
       displayName:
         type: string
+        example: Jane Doe
       companyName:
         type: string
+        example: Company
       department:
         type: string
+        example: Department
       division:
         type: string
+        example: Division
       title:
         type: string
+        example: Trader
       workPhoneNumber:
         type: string
+        example: "+12349999999"
       mobilePhoneNumber:
         type: string
+        example: "+12349999999"
       smsNumber:
         type: string
+        example: "+12349999999"
       accountType:
         type: string
         enum:
           - NORMAL
           - SYSTEM
           - SDL
+        example: NORMAL
       location:
         type: string
+        example: New York
       jobFunction:
         type: string
+        example: Trader
       assetClasses:
         type: array
         items:
           type: string
+        example:
+          - Commodities
       industries:
         type: array
         items:
           type: string
+        example:
+          - Financials
+          - Services
   V2UserDetail:
     description: V2 Detailed User record.
     type: object
@@ -6007,66 +9508,96 @@ definitions:
     properties:
       emailAddress:
         type: string
+        example: johndoe@symphony.com
       firstName:
         type: string
+        example: John
       lastName:
         type: string
+        example: Doe
       userName:
         type: string
+        example: johndoe
       displayName:
         type: string
+        example: John Doe
       companyName:
         type: string
+        example: Company
       department:
         type: string
+        example: Department
       division:
         type: string
+        example: Division
       title:
         type: string
+        example: Trader
       workPhoneNumber:
         type: string
+        example: "+15419999999"
       mobilePhoneNumber:
         type: string
+        example: "+15419999999"
       twoFactorAuthPhone:
         type: string
+        example: "+15419999999"
       smsNumber:
         type: string
+        example: "+15419999999"
       accountType:
         type: string
         enum:
           - NORMAL
           - SYSTEM
           - SDL
+        example: NORMAL
       location:
         type: string
+        example: New York
       recommendedLanguage:
         type: string
+        example: english
       jobFunction:
         type: string
+        example: Trader
       assetClasses:
         type: array
         items:
           type: string
+        example:
+          - Equities
       industries:
         type: array
         items:
           type: string
+        example:
+          - Healthcare
+          - Technology
       marketCoverage:
         type: array
         items:
           type: string
+        example:
+          - EMEA
       responsibility:
         type: array
         items:
           type: string
+        example:
+          - BAU
       function:
         type: array
         items:
           type: string
+        example: 
+          - Trade Processing
       instrument:
         type: array
         items:
           type: string
+        example:
+          - Equities
       currentKey:
         $ref: '#/definitions/V2UserKeyRequest'
       previousKey:
@@ -6078,10 +9609,12 @@ definitions:
       key:
         description: User RSA public key.
         type: string
+        example: -----BEGIN PUBLIC KEY-----\nMIICIANBgkqhw0BAQ...cCAwEAAQ==\n-----END PUBLIC KEY-----
       expirationDate:
         description: RSA key expiration date. This value is set just for rotated keys.
         type: integer
         format: int64
+        example: 1467562406219
       action:
         description: |
           Action to be performed on the RSA key.
@@ -6092,6 +9625,7 @@ definitions:
             - REVOKE
             - EXTEND
         type: string
+        example: SAVE
   V2UserCreate:
     description: |
       V2 User Creation Object.
@@ -6106,10 +9640,60 @@ definitions:
         type: array
         items:
           type: string
+        example:
+          - INDIVIDUAL
+          - COMPLIANCE_OFFICER
   V2UserDetailList:
       type: array
       items:
         $ref: '#/definitions/V2UserDetail'
+      example:
+        - userAttributes:
+            emailAddress: nexus.user@email.com
+            userName: nexus.user
+            displayName: nexus.user
+            accountType: SYSTEM
+          userSystemInfo:
+            id: 9826885173290
+            status: ENABLED
+            suspended: false
+            createdDate: 1499375475000
+            createdBy: "9826885173255"
+            lastUpdatedDate: 1499375475852
+            lastLoginDate: 1504899124191
+          roles:
+            - USER_PROVISIONING
+            - CONTENT_MANAGEMENT
+            - INDIVIDUAL
+        - userAttributes:
+            emailAddress: admin@mail.com
+            firstName: admin
+            lastName: admin
+            userName: admin@mail.com
+            displayName: Admin Admin
+            companyName: Company Name
+            department: Departament
+            division: Division
+            title: Administrator
+            twoFactorAuthPhone: "+15419999999"
+            workPhoneNumber: "+15419999999"
+            mobilePhoneNumber: "+15419999999"
+            accountType: NORMAL
+            assetClasses:
+              - Currencies
+            industries:
+              - Technology
+          userSystemInfo:
+            id: 7696581394433
+            status: ENABLED
+            suspended: false
+            createdDate: 1438054194000
+            lastUpdatedDate: 1527532171729
+            lastLoginDate: 1523912043015
+          roles:
+            - SUPER_COMPLIANCE_OFFICER
+            - INDIVIDUAL
+            - SUPER_ADMINISTRATOR
   UserSystemInfo:
     description: User Status Information.
     type: object
@@ -6117,45 +9701,98 @@ definitions:
       id:
         type: integer
         format: int64
+        example: 7215545078461
       status:
         type: string
         enum:
           - ENABLED
           - DISABLED
+        example: ENABLED
       suspended:
         type: boolean
         description: An optional attribute indicating whether the user is temporarily suspended or not. Since SBE 20.14.
         x-since: 20.14
+        example: true
       suspendedUntil:
         type: integer
         format: int64
         description: An optional unix timestamp until which the suspension is effective. Since SBE 20.14.
         x-since: 20.14
+        example: 1601546400
       suspensionReason:
         type: string
         description: An optional description of the suspension reason. Since SBE 20.14.
         x-since: 20.14
+        example: The user will be OOO due to a mandatory leave
       createdDate:
         type: integer
         format: int64
+        example: 1461508270000
       createdBy:
         type: string
+        example: "7215545057281"
       lastUpdatedDate:
         type: integer
         format: int64
+        example: 1461508270000
       lastLoginDate:
         type: integer
         format: int64
+        example: 1461508270000
       lastPasswordReset:
         type: integer
         format: int64
+        example: 1461508270000
       deactivatedDate:
         type: integer
         format: int64
+        example: 1461508270000
   UserDetailList:
     type: array
     items:
       $ref: '#/definitions/UserDetail'
+    example:
+      - userAttributes:
+          emailAddress: janedoe@symphony.com
+          firstName: Jane
+          lastName: Doe
+          userName: jane.doe
+          displayName: Jane Doe
+          accountType: NORMAL
+          assetClasses:
+            - Commodities
+          industries:
+            - Financials
+            - Healthcare
+        userSystemInfo:
+          id: 9826885173258
+          status: ENABLED
+          suspended: true
+          suspensionReason: The user will be OOO due to a mandatory leave
+          suspendedUntil: 1601546400
+          createdDate: 1499347606000
+          createdBy: "9826885173252"
+          lastUpdatedDate: 1499348554853
+          lastLoginDate: 1504839044527
+        roles:
+          - INDIVIDUAL
+      - userAttributes:
+          emailAddress: nexus.user@email.com
+          userName: nexus.user
+          displayName: nexus.user
+          accountType: SYSTEM
+        userSystemInfo:
+          id: 9826885173290
+          status: ENABLED
+          suspended: false
+          createdDate: 1499375475000
+          createdBy: "9826885173255"
+          lastUpdatedDate: 1499375475852
+          lastLoginDate: 1504899124191
+        roles:
+          - USER_PROVISIONING
+          - CONTENT_MANAGEMENT
+          - INDIVIDUAL
   UserDetail:
     description: Detailed User record.
     type: object
@@ -6183,15 +9820,19 @@ definitions:
       hSalt:
         description: Pod password salt used for PBKDF2 derivation.
         type: string
+        example: hsalt
       hPassword:
         description: Pod password derived with PBKDF2.
         type: string
+        example: hpassword
       khSalt:
         description: Key Manager password salt used for PBKDF2 derivation.
         type: string
+        example: khsalt
       khPassword:
         description: Key Manager password derived with PBKDF2.
         type: string
+        example: khpassword
   MemberInfo:
     description: Detailed membership record.
     type: object
@@ -6199,11 +9840,14 @@ definitions:
       id:
         type: integer
         format: int64
+        example: 7078106103810
       owner:
         type: boolean
+        example: true
       joinDate:
         type: integer
         format: int64
+        example: 1461426797833
       addedThroughGroups:
         description: When the user has been added to the stream through a group (aka SDL), this array contains the group ID which the user belongs to. Since SBE 20.14.
         x-since: 20.14
@@ -6211,11 +9855,25 @@ definitions:
         items:
           type: integer
           format: int64
+        example:
+          - 68719476744
   MembershipList:
     description: List of members in a room.
     type: array
     items:
       $ref: '#/definitions/MemberInfo'
+    example:
+      - id: 7078106103900
+        owner: false
+        joinDate: 1461430710531
+      - id: 7078106103809
+        owner: true
+        joinDate: 1461426797875
+      - id: 7078106103810
+        owner: true
+        joinDate: 1461426797833
+        addedThroughGroups:
+          - 68719476744
   V2MemberUserDetail:
     description: User detail information for stream membership
     type: object
@@ -6223,24 +9881,32 @@ definitions:
       userId:
         type: integer
         format: int64
+        example: 13537736917013
       email:
         type: string
+        example: dpayet@om.fr
       firstName:
         type: string
+        example: Dimitri
       lastName:
         type: string
+        example: Payet
       displayName:
         type: string
         description: Display name for the user
+        example: Dimitri Payet
       company:
         type: string
         description: Company name
+        example: Mars
       companyId:
         type: integer
         description: Company ID
+        example: 13
       isExternal:
         type: boolean
         description: true indicate that this user belong to another company
+        example: true
   V2MemberInfo:
     description: Detailed membership record.
     type: object
@@ -6251,13 +9917,16 @@ definitions:
       isOwner:
         type: boolean
         description: true if this is an owner of the room
+        example: true
       isCreator:
         type: boolean
         description: true if this is the creator of the room
+        example: true
       joinDate:
         description: unix timestamp for join date
         type: integer
         format: int64
+        example: 1604494574047
       addedThroughGroups:
         description: When the user has been added to the stream through a group (aka SDL), this array contains the group ID which the user belongs to. Since SBE 20.14.
         x-since: 20.14
@@ -6265,10 +9934,37 @@ definitions:
         items:
           type: integer
           format: int64
+        example:
+          - 68719476744
   V2MemberInfoList:
     type: array
     items:
       $ref: '#/definitions/V2MemberInfo'
+    example:
+      - user:
+          userId: 13537736917000
+          email: john.doe@symphony.com
+          firstName: John
+          lastName: Doe
+          displayName: John Doe
+          company: pod197
+          companyId: 197
+          isExternal: false
+        isOwner: true
+        isCreator: true
+        joinDate: 1604494574047
+      - user:
+          userId: 13537736917001
+          email: bot@symphony.com
+          displayName: User Provisioning Bot
+          company: pod197
+          companyId: 197
+          isExternal: false
+        isOwner: false
+        isCreator: false
+        joinDate: 1604494605272
+        addedThroughGroups:
+          - 68719476744
   V2MembershipList:
     description: List of members in the stream.
     type: object
@@ -6276,12 +9972,15 @@ definitions:
       count:
         type: integer
         description: total members count
+        example: 
       skip:
         type: integer
         description: number of items to skip from the request
+        example: 
       limit:
         type: integer
         description: maximum number of items to return
+        example: 
       members:
         $ref: '#/definitions/V2MemberInfoList'
   MessageSuppressionResponse:
@@ -6290,12 +9989,15 @@ definitions:
     properties:
       messageId:
         type: string
+        example: _Gj13MiR-5IrVtrmPNl6fn___qvWCYI_dA
       suppressed:
         type: boolean
+        example: true
       suppressionDate:
         type: integer
         format: int64
         description: The date when this message was suppressed.
+        example: 1461565603191
   BulkActionResult:
     description: |
       The results of list based bulk action. The list contains the result messages
@@ -6307,10 +10009,13 @@ definitions:
         enum:
           - SUCCESS
           - FAIL
+        example: SUCCESS
       results:
         type: array
         items:
           type: string
+        example:
+          - ""
   UserConnectionRequest:
     type: object
     description: Request body for the Connection APIs
@@ -6319,6 +10024,7 @@ definitions:
         type: integer
         format: int64
         description: user id
+        example: 769658112378
   UserConnection:
     type: object
     description: Connection status between two users
@@ -6327,6 +10033,7 @@ definitions:
         type: integer
         format: int64
         description: user id
+        example: 769658112378
       status:
         type: string
         description: Connection status between the requesting user and the request sender
@@ -6335,22 +10042,34 @@ definitions:
           - PENDING_OUTGOING
           - ACCEPTED
           - REJECTED
+        example: ACCEPTED
       firstRequestedAt:
         type: integer
         format: int64
         description: unix timestamp when the first request was made
+        example: 1470018073812
       updatedAt:
         type: integer
         format: int64
         description: unix timestamp on the last updated date
+        example: 1471018076255
       requestCounter:
         type: integer
         format: int32
         description: number of requests made
+        example: 1
   UserConnectionList:
     type: array
     items:
       $ref: '#/definitions/UserConnection'
+    example:
+      - userId: 769658112378
+        status: PENDING_OUTGOING
+        firstRequestedAt: 1470018073812
+        updatedAt: 1471018076255
+        requestCounter: 1
+      - userId: 7078106103809
+        status: ACCEPTED
   StreamList:
     description: A list of streams of which the requesting user is a member.
     type: array
@@ -6387,6 +10106,7 @@ definitions:
           - MIM
           - ROOM
           - POST
+        example: ROOM
   ConversationSpecificStreamAttributes:
     type: object
     properties:
@@ -6407,28 +10127,37 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/StreamType'
+        example:
+          - type: IM
+          - type: ROOM
       includeInactiveStreams:
         description: Whether to include inactive streams in the list of results.
         type: boolean
+        example: "false"
   V2StreamAttributes:
     type: object
     properties:
       id:
         type: string
         description: The stream ID.
+        example: BZQYepoT0Zf4vL_jpeMPqn___oEWvVy3dA
       crossPod:
         type: boolean
         description: If true, this is a cross-pod stream.
+        example: false
       origin:
         type: string
         description: INTERNAL if the creator of this stream belongs to the pod, EXTERNAL otherwise
+        example: INTERNAL
       active:
         type: boolean
         description: If true, this stream is active.
+        example: true
       lastMessageDate:
         type: integer
         format: int64
         description: unix timestamp of the last message sent in the stream
+        example: 1644590972696
       streamType:
         description: The type of the stream (IM = IM, multi-IM = MIM, chat room = ROOM, user wall = POST).
         $ref: '#/definitions/V2StreamType'
@@ -6443,6 +10172,7 @@ definitions:
     properties:
       type:
         type: string
+        example: ROOM
   V2ConversationSpecificStreamAttributes:
     type: object
     properties:
@@ -6455,12 +10185,16 @@ definitions:
       name:
         type: string
         description: Room name.
+        example: API room
       groups:
         description: List of groups (aka SDLs) that were added to the room. Since SBE 20.14.
         x-since: 20.14
         type: array
         items:
           $ref: '#/definitions/GroupItem'
+        example:
+          - id: 68719476744
+            addedBy: 68719476743
   V2AdminStreamFilter:
     description: stream filter criteria
     type: object
@@ -6471,42 +10205,52 @@ definitions:
         items:
           description: Valid values are IM, MIM or ROOM
           $ref: '#/definitions/V2AdminStreamType'
+        example:
+          - type: IM
+          - type: ROOM
       scope:
         description: |
           Scope of the room. Valid values are INTERNAL or EXTERNAL.
           If not specified, it will include both Internal and External scope
         type: string
+        example: INTERNAL
       origin:
         description: |
           Origin of the room. It indicates whether the room was created by a user within the company by another company.
           Valid values are INTERNAL or EXTERNAL.
           If not specified, it will include both Internal and External origin
         type: string
+        example: INTERNAL
       status:
         description: |
           Status of the room.
           Valid values are ACTIVE or INACTIVE.
           If not specified, it will include both Active and Inactive status
         type: string
+        example: ACTIVE
       privacy:
         description: |
           Privacy setting of the stream.
           Valid values are PUBLIC or PRIVATE.
           If not specified, it will include both public and private streams
         type: string
+        example: PRIVATE
       startDate:
         description: Start date in unix timestamp in millseconds
         type: integer
         format: int64
+        example: 1481575056047
       endDate:
         description: End date in unix timestamp in millseconds.  If not specified, it assume to be current time.
         type: integer
         format: int64
+        example: 1483038089833
   V2AdminStreamType:
     type: object
     properties:
       type:
         type: string
+        example: ROOM
   AdminJustifiedUserAction:
     type: object
     properties:
@@ -6528,18 +10272,25 @@ definitions:
     properties:
       userId:
         type: string
+        example: 7078106103901
       firstName:
         type: string
+        example: Gustav
       lastName:
         type: string
+        example: Mahler
       displayName:
         type: string
+        example: Gustav Mahler
       email:
         type: string
+        example: gustav.mahler@music.org
       userName:
         type: string
+        example: gmahler
       timestamp:
         type: string
+        example: 1531968487845
   MessageStatus:
     description: |
       Holds the status of a particular message, indicating which user the message has been sent, delivered or read.
@@ -6567,6 +10318,21 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/MessageStatusUser'
+        example:
+          - userId: 7078106103904
+            firsName: Benjamin
+            lastName: Britten
+            displayName: Benjamin Britten
+            email: benjamin.britten@music.org
+            userName: bbritten
+            timestamp: 1484156123000
+          - userId: 7078106103901
+            firsName: Gustav
+            lastName: Mahler
+            displayName: Gustav Mahler
+            email: gmahler@music.org
+            userName: gmahler
+            timestamp: 1531968487845
   ApplicationInfo:
     description: |
       Required information for creating an application.
@@ -6589,6 +10355,12 @@ definitions:
       publisher:
         description: The publisher for this application.
         type: string
+    example:
+      appId: my-test-app
+      name: my-test-app
+      appUrl: https://joe.mydomain.com
+      domain: mydomain.com
+      publisher: Joe Smith
   ApplicationDetail:
     description: Detailed record of application.
     type: object
@@ -6599,14 +10371,17 @@ definitions:
       iconUrl:
         description: Url to a icon to use for app. Must start with "https://".
         type: string
+        example: https://myiconUrl.com
       description:
         description: Description of the application.
         type: string
+        example: a test app
       allowOrigins:
         description: |
           The permitted domains to send or receive a request from.
           The field is for the purpose of CORS which set the app specific "ALLOW-ORIGIN-DOMAINS" header in HTTP.
         type: string
+        example: mydomain.com
       permissions:
         description: |
           List of application permissions provisioned for the application.
@@ -6633,9 +10408,13 @@ definitions:
           type: string
           maxLength: 64
           minLength: 1
+        example:
+          - ACT_AS_USER
+          - SEND_MESSAGES
       cert:
         description: The app public certificate in pem format.
         type: string
+        example: -----BEGIN PUBLIC KEY-----\nMIICIANBgkqhw0BAQ...cCAwEAAQ==\n-----END PUBLIC KEY-----
       authenticationKeys:
         $ref: '#/definitions/AppAuthenticationKeys'
       notification:
@@ -6646,6 +10425,13 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/V2Presence'
+    example:
+      - category: AVAILABLE
+        userId: 14568529068038
+        timestamp: 1533928483800
+      - category: OFFLINE
+        userId: 974217539631
+        timestamp: 1503286226030
   V2Presence:
     allOf:
       - $ref: '#/definitions/V2UserPresence'
@@ -6655,6 +10441,7 @@ definitions:
             type: integer
             format: int64
             description: The time, in milliseconds since Jan 1 1970, when the presence state was set.
+            example: 1533928483800
   V2UserPresence:
     allOf:
       - $ref: '#/definitions/V2PresenceStatus'
@@ -6664,6 +10451,7 @@ definitions:
             type: integer
             format: int64
             description: The ID of the user to whom the presence state relates.
+            example: 14568529068038
   V2PresenceStatus:
     type: object
     properties:
@@ -6682,6 +10470,7 @@ definitions:
             - OUT_OF_OFFICE
             - OFF_WORK
             - OFFLINE
+        example: AWAY
     required:
       - category
   V2AdminStreamList:
@@ -6692,12 +10481,15 @@ definitions:
         type: integer
         format: int64
         description: total number of streams which match the filter criteria
+        example: 4
       skip:
         type: integer
         description: number of streams skipped
+        example: 0
       limit:
         type: integer
         description: maximum number of streams return
+        example: 50
       filter:
         # filter criteria used in the request
         $ref: '#/definitions/V2AdminStreamFilter'
@@ -6709,6 +10501,37 @@ definitions:
     description: list of stream info
     items:
       $ref: '#/definitions/V2AdminStreamInfo'
+    example:
+      - id: Q2KYGm7JkljrgymMajYTJ3___qcLPr1UdA
+        isExternal: false
+        isActive: true
+        isPublic: false
+        type: ROOM
+        attributes:
+          roomName: Active Internal Private Room
+          roomDescription: Active Internal Private Room
+          createdByUserId: 8933531975689
+          createdDate: 1481575056047
+          lastModifiedDate: 1481575056047
+          originCompany: Symphony
+          originCompanyId: 130
+          membersCount: 1
+          lastMessageDate: 1516699467959
+      - id: _KnoYrMkhEn3H2_8vE0kl3___qb5SANQdA
+        isExternal: true
+        isActive: false
+        isPublic: false
+        type: ROOM
+        attributes:
+          roomName: Inactive External Room
+          roomDescription: Inactive External Room
+          createdByUserId: 8933531975686
+          createdDate: 1481876438194
+          lastModifiedDate: 1481876438194
+          originCompany: Symphony
+          originCompanyId: 130
+          membersCount: 2
+          lastMessageDate: 1516699467959
   V2AdminStreamInfo:
     description: Stream information
     type: object
@@ -6716,24 +10539,31 @@ definitions:
       id:
         type: string
         description: stream id
+        example: Q2KYGm7JkljrgymMajYTJ3___qcLPr1UdA
       isExternal:
         type: boolean
         description: true indicate this stream has the scope of external and false indictate this stream has the scope of internal. Deprecated, use origin
+        example: false
       isActive:
         type: boolean
         description: true indicate that this stream has the status of active and false indicate this stream has the scope of inactive
+        example: true
       isPublic:
         type: boolean
         description: true indicate that this stream has a privacy setting of public.  This only apply a ROOM stream type.
+        example: false
       type:
         type: string
         description: type of stream (IM, MIM, ROOM)
+        example: ROOM
       crossPod:
         type: boolean
         description: If true, this is a cross-pod stream.
+        example: false
       origin:
         type: string
         description: INTERNAL if the creator of this stream belongs to the pod, EXTERNAL otherwise
+        example: INTERNAL
       attributes:
         # additional optional properties of the stream
         $ref: '#/definitions/V2AdminStreamAttributes'
@@ -6744,44 +10574,57 @@ definitions:
       roomName:
         type: string
         description: room name (room only)
+        example: API room
       roomDescription:
         type: string
         description: description of the room (room only)
+        example: Room created via API
       members:
         type: array
         description: list of userid who is member of the stream - im or mim only
         items:
           type: integer
           format: int64
+        example: 
+          - 8933531975686
+          - 8933531975689
       createdByUserId:
         type: integer
         format: int64
         description: creator user id
+        example: 8933531975689
       createdDate:
         type: integer
         format: int64
         description: created date
+        example: 1481575056047
       lastModifiedDate:
         type: integer
         format: int64
         description: last modified date
+        example: 1481575056047
       originCompany:
         type: string
         description: company name of the creator
+        example: Symphony
       originCompanyId:
         type: integer
         description: company id of the creator
+        example: 130
       membersCount:
         type: integer
         description: total number of members in the stream
+        example: 1
       lastMessageDate:
         type: integer
         format: int64
         description: last date a message was sent in this stream
+        example: 1516699467959
       groupChat:
         type: boolean
         description: whether a stream is a group chat or not. Since SBE 20.16.
         x-since: 20.16
+        example: false
   FileExtension:
     type: object
     required:
@@ -6867,6 +10710,7 @@ definitions:
       scheme:
         type: string
         description: "URI protocol scheme (example: http, https, ftp)"
+        example: skype
   AppAuthenticationKeys:
     description: App RSA keys information.
     type: object
@@ -6882,10 +10726,12 @@ definitions:
       key:
         description: Application RSA public key.
         type: string
+        example: -----BEGIN PUBLIC KEY-----\nMIICIANBgkqhw0BAQ...cCAwEAAQ==\n-----END PUBLIC KEY-----
       expirationDate:
         description: RSA key expiration date. This value is set just for rotated keys.
         type: integer
         format: int64
+        example: 1700815176000
       action:
         description: |
           Action to be performed on the RSA key.
@@ -6896,6 +10742,7 @@ definitions:
             - REVOKE
             - EXTEND
         type: string
+        example: SAVE
   AppNotification:
     type: object
     description: Application callback information
@@ -6903,15 +10750,22 @@ definitions:
       url:
         type: string
         description: "callback URL"
+        example: https://some.url
       apiKey:
         type: string
         description: "apiKey sent into every callback request, using the X-API-KEY header"
+        example: test123456
   AppProperties:
     type: array
     description: Application configuration properties that are shared with the extension application, client side. Do not store sensitive information here. Since SBE 20.14.
     x-since: 20.14
     items:
       $ref: '#/definitions/AppProperty'
+    example:
+      - key: port
+        value: 4000
+      - key: url
+        value: https://someother.url
   AppProperty:
     type: object
     description: Application configuration property that is shared with the extension application, client side. Do not store sensitive information here.
@@ -6922,6 +10776,9 @@ definitions:
       value:
         type: string
         description: Value of an application configuration property. It cannot be null and its length is limited to 4096 characters. It can be empty.
+    example:
+      key: port
+      value: 4000
   StreamAttachmentResponse:
     type: array
     items:
@@ -6932,24 +10789,31 @@ definitions:
     properties:
       messageId:
         type: string
+        example: PYLHNm/1K6p...peOpj+FbQ
       ingestionDate:
         type: integer
         format: int64
+        example: 1548089933946
       userId:
         type: integer
         format: int64
+        example: 14568529068038
       fileId:
         type: string
         description: The attachment File ID.
+        example: internal_14362
       name:
         type: string
         description: The file name.
+        example: butterfly.jpg
       size:
         type: integer
         format: int64
         description: Size in bytes.
+        example: 70186
       content-type:
         type: string
+        example: image/jpeg
       previews:
         type: array
         items:
@@ -6961,9 +10825,11 @@ definitions:
       fileId:
         type: string
         description: The preview file ID
+        example: internal_14362
       width:
         type: integer
         description: The preview image width
+        example: 600
   UserGroupCreate:
     description: Body for group creation
     type: object
@@ -7099,18 +10965,23 @@ definitions:
         type: integer
         format: int64
         description: User ID
+        example: 7215545058329
       username:
         type: string
         description: Username
+        example: dpayet
       firstName:
         type: string
         description: User first name
+        example: Dimitri
       lastName:
         type: string
         description: User last name
+        example: Payet
       emailAddress:
         type: string
         description: User email addressIntegrationUserManagerTest
+        example: dpayet@om.fr
   UserGroupMembershipRequest:
     description: Body for user group membership creation
     type: object
@@ -7301,9 +11172,11 @@ definitions:
     properties:
       fileName:
         type: string
+        example: Untitled Document.txt
       timestamp:
         type: integer
         format: int64
+        example: 1552999335740
   MessageReceiptDetail:
     description: Message receipt details response object
     type: object
@@ -7314,18 +11187,24 @@ definitions:
         description: Timestamp of message delivery receipts
         type: integer
         format: int64
+        example: 1552999333784
       readReceiptTimestamp:
         description: Timestamp of message read receipts
         type: integer
         format: int64
+        example: 1552999335114
       emailNotificationTimestamp:
         description: Timestamp of message email notifications
         type: integer
         format: int64
+        example: 1552999335114
       downloadReceiptCounts:
         type: array
         items:
           $ref: '#/definitions/DownloadReceiptCount'
+        example:
+          - fileName: Untitled Document.txt
+            timestamp: 1552999335740
   MessageReceiptDetailResponse:
     description: List of Message receipt details
     type: object
@@ -7339,20 +11218,40 @@ definitions:
       creationDate:
         type: integer
         format: int64
+        example: 1552999333141
       deliveryReceiptCount:
         type: integer
+        example: 1
       readReceiptCount:
         type: integer
+        example: 1
       emailNotificationCount:
         type: integer
+        example: 1
       downloadReceiptCounts:
         type: array
         items:
           $ref: '#/definitions/MessageDownloadReceiptCount'
+        example:
+          - fileName: internal_70781
+            count: 1
       MessageReceiptDetail:
         type: array
         items:
           $ref: '#/definitions/MessageReceiptDetail'
+        example:
+          - user:
+              id: 7215545058329
+              username: dpayet
+              firstName: Dimitri
+              lastName: Payet
+              emailAddress: dpayet@om.fr
+            deliveryReceiptTimestamp: 1552999333784
+            readReceiptTimestamp: 1552999335114
+            emailNotificationTimestamp: 1552999335114
+            downloadReceiptCounts:
+              - fileName: Untitled Document.txt
+                timestamp: 1552999335740
       pagination:
         $ref: "#/definitions/Pagination"
   MessageUser:
@@ -7361,25 +11260,32 @@ definitions:
       id:
         type: integer
         format: int64
+        example: 7215545058329
       name:
         type: string
+        example: User Test
   MessageStream:
     type: object
     properties:
       id:
         type: string
+        example: lFpyw0ATFmji+Cc/cSzbk3///pZkWpe1dA==
       name:
         type: string
+        example: Test Room
       streamType:
         type: string
+        example: ROOM
   MessageDownloadReceiptCount:
     type: object
     properties:
       fileName:
         type: string
+        example: internal_707810
       count:
         type: integer
         format: int64
+        example: 1
   MessageDetail:
     description: Message detail
     type: object
@@ -7490,11 +11396,14 @@ definitions:
     properties:
       suspended:
         type: boolean
+        example: true
       suspendedUntil:
         type: integer
         format: int64
+        example: 1601546400
       suspensionReason:
         type: string
+        example: The user will be OOO due to a mandatory leave
   FollowersList:
     type: object
     properties:
@@ -7506,11 +11415,15 @@ definitions:
       count:
         type: integer
         format: int64
+        example: 2
       followers:
         type: array
         items:
           type: integer
           format: int64
+        example:
+          - 13056700579848
+          - 13056700580889
       pagination:
         $ref: '#/definitions/Pagination'
   FollowingListResponse:
@@ -7519,11 +11432,15 @@ definitions:
       count:
         type: integer
         format: int64
+        example: 2
       following:
         type: array
         items:
           type: integer
           format: int64
+        example:
+          - 13056700579848
+          - 13056700580889
       pagination:
         $ref: '#/definitions/Pagination'
   V1IMAttributes:
@@ -7532,6 +11449,7 @@ definitions:
       pinnedMessageId:
         type: string
         description: UrlSafe message id of the pinned message inside the IM. To perform unpin operation, send an empty string.
+        example: vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ
   V1IMDetail:
     type: object
     properties:
@@ -7544,13 +11462,16 @@ definitions:
     properties:
       id:
         type: string
+        example: usnBKBkH_BVrGOiVpaupEH___okFfE7QdA
       creationDate:
         type: integer
         format: int64
         description: The datetime when the stream was originally created. Milliseconds since Jan 1 1970.
+        example: 1610520703317
       active:
         type: boolean
         description: If false, no messages can be sent in this stream, and membership is locked.
+        example: true
   ServiceAccountManifest:
     type: object
     properties:

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -74,7 +74,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -169,7 +169,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -230,7 +230,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -324,7 +324,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -390,7 +390,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -464,7 +464,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -541,7 +541,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -624,7 +624,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -732,7 +732,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -804,7 +804,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -820,7 +820,7 @@ paths:
               code: 403
               message: The user lacks the required entitlement to perform this operation
         '404':
-          description: 'Not Found: Connection cannot be found.'
+          description: 'Not Found: User cannot be found.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -876,7 +876,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -951,7 +951,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1018,7 +1018,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1089,7 +1089,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1174,7 +1174,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1244,7 +1244,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1315,7 +1315,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1376,7 +1376,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1442,7 +1442,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1504,7 +1504,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1589,7 +1589,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1716,7 +1716,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1795,7 +1795,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1872,7 +1872,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -1959,7 +1959,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2033,7 +2033,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2099,7 +2099,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2165,7 +2165,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2231,7 +2231,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2299,7 +2299,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2349,7 +2349,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2427,7 +2427,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2557,7 +2557,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2619,7 +2619,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2682,7 +2682,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2745,7 +2745,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2813,7 +2813,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2907,7 +2907,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -2977,7 +2977,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3097,7 +3097,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3178,7 +3178,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3275,7 +3275,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3344,7 +3344,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3449,7 +3449,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3508,7 +3508,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3581,7 +3581,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3648,7 +3648,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3718,7 +3718,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3778,7 +3778,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3848,7 +3848,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3921,7 +3921,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -3996,7 +3996,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -4063,7 +4063,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -4136,7 +4136,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -4193,7 +4193,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -4263,7 +4263,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -4324,7 +4324,7 @@ paths:
                 code: 400
                 message: // Client error, see response body for further details.
           '401':
-            description: 'Unauthorized: Session tokens invalid.'
+            description: 'Unauthorized: Invalid session token.'
             schema:
               $ref: '#/definitions/Error'
             examples:
@@ -4397,7 +4397,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -4459,7 +4459,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -4521,7 +4521,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -4632,7 +4632,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -4743,7 +4743,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -4811,7 +4811,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -4879,7 +4879,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -4965,7 +4965,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5047,7 +5047,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5129,7 +5129,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5194,7 +5194,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5262,7 +5262,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5333,7 +5333,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5395,7 +5395,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5463,7 +5463,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5525,7 +5525,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5593,7 +5593,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5666,7 +5666,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5734,7 +5734,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5802,7 +5802,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5870,7 +5870,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -5952,7 +5952,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6032,7 +6032,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6088,7 +6088,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6137,7 +6137,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6199,7 +6199,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6266,7 +6266,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6404,7 +6404,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6511,7 +6511,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6568,7 +6568,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6620,7 +6620,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6687,7 +6687,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6748,7 +6748,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6803,7 +6803,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6873,7 +6873,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -6969,7 +6969,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -7058,7 +7058,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -7144,7 +7144,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -7205,7 +7205,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -7285,7 +7285,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -7341,7 +7341,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -7450,7 +7450,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -7550,7 +7550,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -7645,7 +7645,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -7701,7 +7701,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -7962,7 +7962,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -8044,7 +8044,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:
@@ -8111,7 +8111,7 @@ paths:
               code: 400
               message: // Client error, see response body for further details.
         '401':
-          description: 'Unauthorized: Session tokens invalid.'
+          description: 'Unauthorized: Invalid session token.'
           schema:
             $ref: '#/definitions/Error'
           examples:


### PR DESCRIPTION
Added examples to the swagger specs.

Main items to be investigated (why it is not displayed in Gitbook):
- List streams for enterprise --> streamTypes (empty)
- Search Rooms
- Presence body object of V2UserPresence --> External Presence interest + Set Other User Presence
- Update User Features
- Update App request bodies
- Add IB Group members
- List certificate types